### PR TITLE
Implement JWT authentication with RBAC support

### DIFF
--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -1,37 +1,179 @@
-"""
-Authentication endpoints
-"""
+"""Authentication endpoints."""
 
-from fastapi import APIRouter
-from pydantic import BaseModel
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import RoleBasedAccess, get_current_user
+from app.core.config import settings
+from app.db import get_async_session
+from app.models.user import User, UserRole
+from app.schemas import (
+    LoginRequest,
+    RefreshTokenRequest,
+    RefreshTokenResponse,
+    TokenResponse,
+    UserCreate,
+    UserRead,
+)
+from app.services import (
+    create_user,
+    get_user_by_id,
+    get_user_by_username,
+    user_exists_with_username_or_email,
+)
+from app.utils import (
+    InvalidTokenError,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    verify_password,
+)
 
 router = APIRouter()
 
 
-class LoginRequest(BaseModel):
-    username: str
-    password: str
+@router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+async def register_user(
+    user_in: UserCreate,
+    session: AsyncSession = Depends(get_async_session),
+) -> User:
+    """Register a new user account."""
+    if await user_exists_with_username_or_email(
+        session, username=user_in.username, email=user_in.email
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Username or email already registered",
+        )
+
+    try:
+        user = await create_user(session, user_in)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return user
 
 
-class LoginResponse(BaseModel):
-    access_token: str
-    token_type: str
-    expires_in: int
+@router.post("/login", response_model=TokenResponse)
+async def login(
+    request: LoginRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> TokenResponse:
+    """Authenticate a user and issue JWT tokens."""
+    user = await get_user_by_username(session, request.username)
 
+    if user is None or not verify_password(request.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
-@router.post("/login", response_model=LoginResponse)
-async def login(request: LoginRequest):
-    """User login endpoint"""
-    # TODO: Implement actual authentication logic
-    return LoginResponse(
-        access_token="dummy-token",
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is inactive",
+        )
+
+    access_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    refresh_expires = timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+
+    access_token = create_access_token(
+        subject=str(user.id),
+        username=user.username,
+        role=user.role.value,
+        expires_delta=access_expires,
+    )
+    refresh_token = create_refresh_token(
+        subject=str(user.id),
+        username=user.username,
+        role=user.role.value,
+        expires_delta=refresh_expires,
+    )
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
         token_type="bearer",
-        expires_in=900
+        expires_in=int(access_expires.total_seconds()),
     )
 
 
+@router.post("/refresh", response_model=RefreshTokenResponse)
+async def refresh_access_token(
+    request: RefreshTokenRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> RefreshTokenResponse:
+    """Generate a new access token from a refresh token."""
+    try:
+        payload = decode_token(request.refresh_token, expected_type="refresh")
+    except InvalidTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    user_id = payload.get("sub")
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token payload missing subject",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token subject",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    user = await get_user_by_id(session, user_id_int)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is inactive",
+        )
+
+    access_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    new_access_token = create_access_token(
+        subject=str(user.id),
+        username=user.username,
+        role=user.role.value,
+        expires_delta=access_expires,
+    )
+
+    return RefreshTokenResponse(
+        access_token=new_access_token,
+        expires_in=int(access_expires.total_seconds()),
+        issued_at=datetime.now(timezone.utc),
+    )
+
+
+@router.get("/me", response_model=UserRead)
+async def read_current_user(current_user: User = Depends(get_current_user)) -> User:
+    """Return the authenticated user's profile."""
+    return current_user
+
+
 @router.post("/logout")
-async def logout():
-    """User logout endpoint"""
-    # TODO: Implement logout logic (token blacklisting)
-    return {"message": "Successfully logged out"}
+async def logout(current_user: User = Depends(RoleBasedAccess(list(UserRole)))) -> dict[str, str]:
+    """Placeholder logout endpoint relying on RBAC dependency."""
+    return {"message": f"User {current_user.username} logged out"}

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,104 @@
+"""Reusable FastAPI dependencies."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_async_session
+from app.models.user import User, UserRole
+from app.utils import InvalidTokenError, decode_token
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
+    session: AsyncSession = Depends(get_async_session),
+) -> User:
+    """Resolve the currently authenticated user based on the Authorization header."""
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = credentials.credentials
+
+    try:
+        payload = decode_token(token, expected_type="access")
+    except InvalidTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    user_id = payload.get("sub")
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token payload missing subject",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token subject",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    result = await session.execute(select(User).where(User.id == user_id_int))
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is inactive",
+        )
+
+    return user
+
+
+class RoleBasedAccess:
+    """Dependency that enforces role-based access control."""
+
+    def __init__(self, roles: Sequence[UserRole | str]):
+        if not roles:
+            msg = "At least one role must be provided"
+            raise ValueError(msg)
+        self._allowed_roles = {self._normalise_role(role) for role in roles}
+
+    def _normalise_role(self, role: UserRole | str) -> UserRole:
+        if isinstance(role, UserRole):
+            return role
+        try:
+            return UserRole(role)
+        except ValueError as exc:  # pragma: no cover - guard against bad configuration
+            raise ValueError(f"Unknown role: {role}") from exc
+
+    async def __call__(self, user: User = Depends(get_current_user)) -> User:
+        if user.role not in self._allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient permissions",
+            )
+        return user
+
+
+__all__ = ["RoleBasedAccess", "get_current_user"]

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,8 @@
+"""Database utilities for the application."""
+
+from .session import async_session_factory, get_async_session
+
+__all__ = [
+    "async_session_factory",
+    "get_async_session",
+]

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,29 @@
+"""Database session management helpers."""
+
+from collections.abc import AsyncIterator
+from typing import Final
+
+from sqlalchemy.ext.asyncio import (AsyncSession, async_sessionmaker,
+                                    create_async_engine)
+
+from app.core.config import settings
+
+# Create async engine and session factory
+_engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=settings.DEBUG,
+    future=True,
+    pool_pre_ping=True,
+)
+
+async_session_factory: Final[async_sessionmaker[AsyncSession]] = async_sessionmaker(
+    _engine,
+    expire_on_commit=False,
+    autoflush=False,
+)
+
+
+async def get_async_session() -> AsyncIterator[AsyncSession]:
+    """FastAPI dependency that yields an :class:`AsyncSession`."""
+    async with async_session_factory() as session:
+        yield session

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,1 +1,20 @@
-# Pydantic schemas
+"""Pydantic schemas exposed by the application."""
+
+from .auth import (
+    LoginRequest,
+    RefreshTokenRequest,
+    RefreshTokenResponse,
+    TokenPayload,
+    TokenResponse,
+)
+from .user import UserCreate, UserRead
+
+__all__ = [
+    "LoginRequest",
+    "RefreshTokenRequest",
+    "RefreshTokenResponse",
+    "TokenPayload",
+    "TokenResponse",
+    "UserCreate",
+    "UserRead",
+]

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,53 @@
+"""Schemas for authentication endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.user import UserRole
+
+
+class LoginRequest(BaseModel):
+    """Payload for login requests."""
+
+    username: str = Field(min_length=3, max_length=50)
+    password: str = Field(min_length=8, max_length=128)
+
+
+class TokenResponse(BaseModel):
+    """Response returned when issuing JWT tokens."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+    expires_in: int
+
+
+class TokenPayload(BaseModel):
+    """Structure of the JWT payload we expect from generated tokens."""
+
+    sub: str
+    username: str
+    role: UserRole
+    type: str
+    exp: int
+    iat: int
+
+
+class RefreshTokenRequest(BaseModel):
+    """Payload for refreshing access tokens."""
+
+    refresh_token: str
+
+
+class RefreshTokenResponse(BaseModel):
+    """Response returned when a refresh token is exchanged."""
+
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+    issued_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,34 @@
+"""Pydantic schemas for user related operations."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from app.models.user import UserRole
+
+
+class UserBase(BaseModel):
+    """Shared user attributes."""
+
+    username: str = Field(min_length=3, max_length=50)
+    email: EmailStr
+    full_name: str = Field(min_length=1, max_length=120)
+    department: Optional[str] = Field(default=None, max_length=100)
+    role: UserRole
+
+
+class UserCreate(UserBase):
+    """Schema for user registration input."""
+
+    password: str = Field(min_length=8, max_length=128)
+
+
+class UserRead(UserBase):
+    """Schema returned for user information."""
+
+    id: int
+    is_active: bool
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,1 +1,17 @@
-# Business logic services
+"""Domain service layer exports."""
+
+from .user import (
+    create_user,
+    get_user_by_email,
+    get_user_by_id,
+    get_user_by_username,
+    user_exists_with_username_or_email,
+)
+
+__all__ = [
+    "create_user",
+    "get_user_by_email",
+    "get_user_by_id",
+    "get_user_by_username",
+    "user_exists_with_username_or_email",
+]

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -1,0 +1,63 @@
+"""Service helpers for interacting with user records."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from app.schemas.user import UserCreate
+from app.utils.security import get_password_hash
+
+
+async def get_user_by_id(session: AsyncSession, user_id: int) -> Optional[User]:
+    """Return the user with the supplied primary key, if present."""
+    result = await session.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_username(session: AsyncSession, username: str) -> Optional[User]:
+    """Return the user with the supplied *username*, if present."""
+    result = await session.execute(select(User).where(User.username == username))
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_email(session: AsyncSession, email: str) -> Optional[User]:
+    """Return the user with the supplied *email*, if present."""
+    result = await session.execute(select(User).where(User.email == email))
+    return result.scalar_one_or_none()
+
+
+async def create_user(session: AsyncSession, user_in: UserCreate) -> User:
+    """Persist a new user to the database."""
+    user = User(
+        username=user_in.username,
+        email=user_in.email,
+        full_name=user_in.full_name,
+        department=user_in.department,
+        role=user_in.role,
+        password_hash=get_password_hash(user_in.password),
+    )
+    session.add(user)
+
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise ValueError("Username or email already exists") from exc
+
+    await session.refresh(user)
+    return user
+
+
+async def user_exists_with_username_or_email(
+    session: AsyncSession, *, username: str, email: str
+) -> bool:
+    """Check whether a user already exists with the provided username or email."""
+    result = await session.execute(
+        select(User.id).where(or_(User.username == username, User.email == email))
+    )
+    return result.first() is not None

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,1 +1,19 @@
-# Utility functions
+"""Utility helpers for the backend application."""
+
+from .security import (
+    InvalidTokenError,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    get_password_hash,
+    verify_password,
+)
+
+__all__ = [
+    "InvalidTokenError",
+    "create_access_token",
+    "create_refresh_token",
+    "decode_token",
+    "get_password_hash",
+    "verify_password",
+]

--- a/backend/app/utils/security.py
+++ b/backend/app/utils/security.py
@@ -1,0 +1,119 @@
+"""Security related helper functions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from app.core.config import settings
+
+
+class InvalidTokenError(Exception):
+    """Raised when a provided JWT token cannot be validated."""
+
+
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def get_password_hash(password: str) -> str:
+    """Hash *password* using the configured password hashing context."""
+    return _pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Validate that *plain_password* matches *hashed_password*."""
+    return _pwd_context.verify(plain_password, hashed_password)
+
+
+def _create_token(
+    *,
+    subject: str,
+    username: str,
+    role: str,
+    token_type: str,
+    expires_delta: timedelta,
+    additional_claims: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Create a JWT token containing the supplied metadata."""
+    now = datetime.now(timezone.utc)
+    expire = now + expires_delta
+
+    payload: Dict[str, Any] = {
+        "sub": subject,
+        "iat": int(now.timestamp()),
+        "exp": int(expire.timestamp()),
+        "type": token_type,
+        "username": username,
+        "role": role,
+    }
+
+    if additional_claims:
+        payload.update(additional_claims)
+
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def create_access_token(
+    *,
+    subject: str,
+    username: str,
+    role: str,
+    expires_delta: Optional[timedelta] = None,
+    additional_claims: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Create a signed JWT access token for the given subject."""
+    delta = expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return _create_token(
+        subject=subject,
+        username=username,
+        role=role,
+        token_type="access",
+        expires_delta=delta,
+        additional_claims=additional_claims,
+    )
+
+
+def create_refresh_token(
+    *,
+    subject: str,
+    username: str,
+    role: str,
+    expires_delta: Optional[timedelta] = None,
+    additional_claims: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Create a signed JWT refresh token for the given subject."""
+    delta = expires_delta or timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    return _create_token(
+        subject=subject,
+        username=username,
+        role=role,
+        token_type="refresh",
+        expires_delta=delta,
+        additional_claims=additional_claims,
+    )
+
+
+def decode_token(token: str, *, expected_type: Optional[str] = None) -> Dict[str, Any]:
+    """Decode *token* and optionally verify the ``type`` claim."""
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+    except JWTError as exc:  # pragma: no cover - defensive, depends on external lib
+        raise InvalidTokenError("Could not validate credentials") from exc
+
+    if expected_type is not None and payload.get("type") != expected_type:
+        raise InvalidTokenError("Invalid token type")
+
+    return payload
+
+
+__all__ = [
+    "InvalidTokenError",
+    "create_access_token",
+    "create_refresh_token",
+    "decode_token",
+    "get_password_hash",
+    "verify_password",
+]


### PR DESCRIPTION
## Summary
- add reusable JWT helpers for password hashing, token generation, and validation
- introduce async database session helpers, user service utilities, and FastAPI dependencies for authentication and RBAC
- implement registration, login, refresh, profile, and logout endpoints leveraging the new infrastructure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8f710811483288c8e303520587056