### PR TITLE
Implement vehicle management CRUD APIs

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -4,7 +4,7 @@ API v1 router
 
 from fastapi import APIRouter
 
-from app.api.api_v1.endpoints import auth, health, users
+from app.api.api_v1.endpoints import auth, health, users, vehicles
 
 api_router = APIRouter()
 
@@ -12,3 +12,4 @@ api_router = APIRouter()
 api_router.include_router(health.router, prefix="/health", tags=["health"])
 api_router.include_router(auth.router, prefix="/auth", tags=["authentication"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
+api_router.include_router(vehicles.router, prefix="/vehicles", tags=["vehicles"])

--- a/backend/app/api/api_v1/endpoints/vehicles.py
+++ b/backend/app/api/api_v1/endpoints/vehicles.py
@@ -1,0 +1,141 @@
+"""Vehicle management API endpoints."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import RoleBasedAccess
+from app.core.config import settings
+from app.db import get_async_session
+from app.models.user import User, UserRole
+from app.models.vehicle import VehicleStatus, VehicleType
+from app.schemas import VehicleCreate, VehicleRead, VehicleStatusUpdate, VehicleUpdate
+from app.services import (
+    create_vehicle,
+    delete_vehicle as delete_vehicle_service,
+    get_vehicle_by_id,
+    list_vehicles,
+    update_vehicle as update_vehicle_service,
+    update_vehicle_status as update_vehicle_status_service,
+)
+
+router = APIRouter()
+
+_management_roles = (UserRole.FLEET_ADMIN, UserRole.MANAGER)
+_manage_vehicles = RoleBasedAccess(_management_roles)
+
+
+@router.get("/", response_model=list[VehicleRead])
+async def list_vehicles_endpoint(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(
+        default=settings.DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=settings.MAX_PAGE_SIZE,
+    ),
+    status: Optional[VehicleStatus] = None,
+    vehicle_type: Optional[VehicleType] = None,
+    search: Optional[str] = Query(default=None, min_length=1),
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_vehicles),
+) -> list[VehicleRead]:
+    """List vehicles with optional filtering and pagination."""
+    search_term = search.strip() if search else None
+    return await list_vehicles(
+        session,
+        skip=skip,
+        limit=limit,
+        status=status,
+        vehicle_type=vehicle_type,
+        search=search_term,
+    )
+
+
+@router.post("/", response_model=VehicleRead, status_code=status.HTTP_201_CREATED)
+async def create_vehicle_endpoint(
+    vehicle_in: VehicleCreate,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_vehicles),
+) -> VehicleRead:
+    """Create a new vehicle entry."""
+    try:
+        return await create_vehicle(session, vehicle_in)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.get("/{vehicle_id}", response_model=VehicleRead)
+async def get_vehicle_detail(
+    vehicle_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_vehicles),
+) -> VehicleRead:
+    """Retrieve a vehicle by its identifier."""
+    vehicle = await get_vehicle_by_id(session, vehicle_id)
+    if vehicle is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vehicle not found")
+    return vehicle
+
+
+@router.patch("/{vehicle_id}", response_model=VehicleRead)
+async def update_vehicle_endpoint(
+    vehicle_id: int,
+    vehicle_update: VehicleUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_vehicles),
+) -> VehicleRead:
+    """Update vehicle information."""
+    vehicle = await get_vehicle_by_id(session, vehicle_id)
+    if vehicle is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vehicle not found")
+
+    try:
+        return await update_vehicle_service(
+            session,
+            vehicle=vehicle,
+            vehicle_update=vehicle_update,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.patch("/{vehicle_id}/status", response_model=VehicleRead)
+async def update_vehicle_status_endpoint(
+    vehicle_id: int,
+    status_update: VehicleStatusUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_vehicles),
+) -> VehicleRead:
+    """Update only the status of a vehicle."""
+    vehicle = await get_vehicle_by_id(session, vehicle_id)
+    if vehicle is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vehicle not found")
+
+    return await update_vehicle_status_service(
+        session,
+        vehicle=vehicle,
+        status=status_update.status,
+    )
+
+
+@router.delete("/{vehicle_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_vehicle_endpoint(
+    vehicle_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_vehicles),
+) -> None:
+    """Delete a vehicle from the fleet."""
+    vehicle = await get_vehicle_by_id(session, vehicle_id)
+    if vehicle is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vehicle not found")
+
+    await delete_vehicle_service(session, vehicle=vehicle)

--- a/backend/app/models/vehicle.py
+++ b/backend/app/models/vehicle.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Optional
 from datetime import date
-from sqlalchemy import String, Integer, Date, Text
+from sqlalchemy import Date, Enum as SQLAlchemyEnum, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base, TimestampMixin
@@ -39,14 +39,27 @@ class Vehicle(Base, TimestampMixin):
     __tablename__ = "vehicles"
     
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    registration_number: Mapped[str] = mapped_column(String(20), unique=True, nullable=False, index=True)
-    vehicle_type: Mapped[VehicleType] = mapped_column(nullable=False, index=True)
+    registration_number: Mapped[str] = mapped_column(
+        String(20), unique=True, nullable=False, index=True
+    )
+    vehicle_type: Mapped[VehicleType] = mapped_column(
+        SQLAlchemyEnum(VehicleType, name="vehicletype"), nullable=False, index=True
+    )
     brand: Mapped[str] = mapped_column(String(60), nullable=False)
     model: Mapped[str] = mapped_column(String(60), nullable=False)
     year_manufactured: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     seating_capacity: Mapped[int] = mapped_column(Integer, nullable=False)
-    fuel_type: Mapped[FuelType] = mapped_column(default=FuelType.GASOLINE, nullable=False)
-    status: Mapped[VehicleStatus] = mapped_column(default=VehicleStatus.ACTIVE, nullable=False, index=True)
+    fuel_type: Mapped[FuelType] = mapped_column(
+        SQLAlchemyEnum(FuelType, name="fueltype"),
+        default=FuelType.GASOLINE,
+        nullable=False,
+    )
+    status: Mapped[VehicleStatus] = mapped_column(
+        SQLAlchemyEnum(VehicleStatus, name="vehiclestatus"),
+        default=VehicleStatus.ACTIVE,
+        nullable=False,
+        index=True,
+    )
     current_mileage: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     
     # Document tracking
@@ -59,6 +72,9 @@ class Vehicle(Base, TimestampMixin):
     
     # Relationships
     assignments = relationship("Assignment", back_populates="vehicle")
-    
+
     def __repr__(self) -> str:
-        return f"<Vehicle(id={self.id}, registration='{self.registration_number}', type='{self.vehicle_type}')>"
+        return (
+            f"<Vehicle(id={self.id}, registration='{self.registration_number}',"
+            f" type='{self.vehicle_type}')>"
+        )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -15,6 +15,12 @@ from .user import (
     UserRoleUpdate,
     UserUpdate,
 )
+from .vehicle import (
+    VehicleCreate,
+    VehicleRead,
+    VehicleStatusUpdate,
+    VehicleUpdate,
+)
 
 __all__ = [
     "LoginRequest",
@@ -28,4 +34,8 @@ __all__ = [
     "UserRead",
     "UserRoleUpdate",
     "UserUpdate",
+    "VehicleCreate",
+    "VehicleRead",
+    "VehicleStatusUpdate",
+    "VehicleUpdate",
 ]

--- a/backend/app/schemas/vehicle.py
+++ b/backend/app/schemas/vehicle.py
@@ -1,0 +1,153 @@
+"""Pydantic schemas for vehicle management."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+from app.models.vehicle import FuelType, VehicleStatus, VehicleType
+
+
+def _normalise_basic_text(value: str, field_display: str) -> str:
+    """Strip and validate that *value* contains non-whitespace characters."""
+    trimmed = value.strip()
+    if not trimmed:
+        raise ValueError(f"{field_display.capitalize()} must not be empty")
+    return trimmed
+
+
+def _normalise_registration(value: str) -> str:
+    """Normalise the registration number for consistent storage."""
+    normalised = " ".join(value.strip().upper().split())
+    if not normalised:
+        raise ValueError("Registration number must not be empty")
+    return normalised
+
+
+def _validate_year(year: Optional[int]) -> Optional[int]:
+    """Ensure the manufacturing year is within a sensible range."""
+    if year is None:
+        return None
+
+    current_year = date.today().year + 1
+    if year < 1980 or year > current_year:
+        raise ValueError(
+            "Year manufactured must be between 1980 and one year beyond the current year"
+        )
+    return year
+
+
+class VehicleBase(BaseModel):
+    """Shared fields for vehicle operations."""
+
+    vehicle_type: VehicleType
+    brand: str = Field(..., max_length=60)
+    model: str = Field(..., max_length=60)
+    year_manufactured: Optional[int] = None
+    seating_capacity: int = Field(..., ge=1, le=100)
+    fuel_type: FuelType = FuelType.GASOLINE
+    status: VehicleStatus = VehicleStatus.ACTIVE
+    current_mileage: int = Field(0, ge=0)
+    tax_expiry_date: Optional[date] = None
+    insurance_expiry_date: Optional[date] = None
+    inspection_expiry_date: Optional[date] = None
+    notes: Optional[str] = None
+
+    @field_validator("brand", "model")
+    @classmethod
+    def _validate_text_fields(
+        cls, value: str, info: ValidationInfo
+    ) -> str:
+        return _normalise_basic_text(value, info.field_name.replace("_", " "))
+
+    @field_validator("notes")
+    @classmethod
+    def _normalise_notes(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        return trimmed or None
+
+    @field_validator("year_manufactured")
+    @classmethod
+    def _check_year(cls, value: Optional[int]) -> Optional[int]:
+        return _validate_year(value)
+
+
+class VehicleCreate(VehicleBase):
+    """Schema for creating new vehicles."""
+
+    registration_number: str = Field(..., min_length=1, max_length=20)
+
+    @field_validator("registration_number")
+    @classmethod
+    def _normalise_registration_number(cls, value: str) -> str:
+        return _normalise_registration(value)
+
+
+class VehicleUpdate(BaseModel):
+    """Schema for updating vehicle details."""
+
+    registration_number: Optional[str] = Field(None, min_length=1, max_length=20)
+    vehicle_type: Optional[VehicleType] = None
+    brand: Optional[str] = Field(None, max_length=60)
+    model: Optional[str] = Field(None, max_length=60)
+    year_manufactured: Optional[int] = None
+    seating_capacity: Optional[int] = Field(None, ge=1, le=100)
+    fuel_type: Optional[FuelType] = None
+    status: Optional[VehicleStatus] = None
+    current_mileage: Optional[int] = Field(None, ge=0)
+    tax_expiry_date: Optional[date] = None
+    insurance_expiry_date: Optional[date] = None
+    inspection_expiry_date: Optional[date] = None
+    notes: Optional[str] = None
+
+    @field_validator("registration_number")
+    @classmethod
+    def _normalise_registration_number(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        if value is None:
+            return None
+        return _normalise_registration(value)
+
+    @field_validator("brand", "model")
+    @classmethod
+    def _normalise_optional_text(
+        cls, value: Optional[str], info: ValidationInfo
+    ) -> Optional[str]:
+        if value is None:
+            return None
+        return _normalise_basic_text(value, info.field_name.replace("_", " "))
+
+    @field_validator("notes")
+    @classmethod
+    def _normalise_optional_notes(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        return trimmed or None
+
+    @field_validator("year_manufactured")
+    @classmethod
+    def _check_year(cls, value: Optional[int]) -> Optional[int]:
+        return _validate_year(value)
+
+
+class VehicleStatusUpdate(BaseModel):
+    """Schema for updating only the vehicle status."""
+
+    status: VehicleStatus
+
+
+class VehicleRead(VehicleBase):
+    """Schema for returning vehicle data via the API."""
+
+    id: int
+    registration_number: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -12,6 +12,15 @@ from .user import (
     update_user_profile,
     user_exists_with_username_or_email,
 )
+from .vehicle import (
+    create_vehicle,
+    delete_vehicle,
+    get_vehicle_by_id,
+    get_vehicle_by_registration_number,
+    list_vehicles,
+    update_vehicle,
+    update_vehicle_status,
+)
 
 __all__ = [
     "change_user_password",
@@ -24,4 +33,11 @@ __all__ = [
     "update_user",
     "update_user_profile",
     "user_exists_with_username_or_email",
+    "create_vehicle",
+    "delete_vehicle",
+    "get_vehicle_by_id",
+    "get_vehicle_by_registration_number",
+    "list_vehicles",
+    "update_vehicle",
+    "update_vehicle_status",
 ]

--- a/backend/app/services/vehicle.py
+++ b/backend/app/services/vehicle.py
@@ -1,0 +1,129 @@
+"""Service helpers for interacting with vehicle records."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import Select, func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.vehicle import Vehicle, VehicleStatus, VehicleType
+from app.schemas.vehicle import VehicleCreate, VehicleUpdate
+
+
+async def get_vehicle_by_id(session: AsyncSession, vehicle_id: int) -> Optional[Vehicle]:
+    """Return the vehicle with the supplied primary key, if present."""
+    result = await session.execute(select(Vehicle).where(Vehicle.id == vehicle_id))
+    return result.scalar_one_or_none()
+
+
+async def get_vehicle_by_registration_number(
+    session: AsyncSession, registration_number: str
+) -> Optional[Vehicle]:
+    """Return the vehicle associated with *registration_number*, if any."""
+    normalised = registration_number.strip().upper()
+    result = await session.execute(
+        select(Vehicle).where(func.upper(Vehicle.registration_number) == normalised)
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_vehicles(
+    session: AsyncSession,
+    *,
+    skip: int = 0,
+    limit: Optional[int] = None,
+    status: Optional[VehicleStatus] = None,
+    vehicle_type: Optional[VehicleType] = None,
+    search: Optional[str] = None,
+) -> list[Vehicle]:
+    """Return a list of vehicles filtered by the provided parameters."""
+    stmt: Select[tuple[Vehicle]] = select(Vehicle).order_by(Vehicle.id)
+
+    if status is not None:
+        stmt = stmt.where(Vehicle.status == status)
+
+    if vehicle_type is not None:
+        stmt = stmt.where(Vehicle.vehicle_type == vehicle_type)
+
+    if search:
+        pattern = f"%{search.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(Vehicle.registration_number).like(pattern),
+                func.lower(Vehicle.brand).like(pattern),
+                func.lower(Vehicle.model).like(pattern),
+            )
+        )
+
+    if skip:
+        stmt = stmt.offset(skip)
+
+    if limit is not None:
+        stmt = stmt.limit(limit)
+
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def create_vehicle(session: AsyncSession, vehicle_in: VehicleCreate) -> Vehicle:
+    """Persist a new vehicle record after validating constraints."""
+    existing = await get_vehicle_by_registration_number(
+        session, vehicle_in.registration_number
+    )
+    if existing is not None:
+        raise ValueError("Vehicle with this registration number already exists")
+
+    vehicle = Vehicle(**vehicle_in.model_dump())
+    session.add(vehicle)
+
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise ValueError("Vehicle with this registration number already exists") from exc
+
+    await session.refresh(vehicle)
+    return vehicle
+
+
+async def update_vehicle(
+    session: AsyncSession, *, vehicle: Vehicle, vehicle_update: VehicleUpdate
+) -> Vehicle:
+    """Update the supplied *vehicle* with the provided attributes."""
+    data = vehicle_update.model_dump(exclude_unset=True)
+
+    new_registration = data.get("registration_number")
+    if new_registration and new_registration != vehicle.registration_number:
+        existing = await get_vehicle_by_registration_number(session, new_registration)
+        if existing is not None and existing.id != vehicle.id:
+            raise ValueError("Vehicle with this registration number already exists")
+
+    for field, value in data.items():
+        setattr(vehicle, field, value)
+
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise ValueError("Vehicle with this registration number already exists") from exc
+
+    await session.refresh(vehicle)
+    return vehicle
+
+
+async def update_vehicle_status(
+    session: AsyncSession, *, vehicle: Vehicle, status: VehicleStatus
+) -> Vehicle:
+    """Update only the status field for *vehicle*."""
+    vehicle.status = status
+    await session.commit()
+    await session.refresh(vehicle)
+    return vehicle
+
+
+async def delete_vehicle(session: AsyncSession, *, vehicle: Vehicle) -> None:
+    """Delete the supplied *vehicle* from the database."""
+    await session.delete(vehicle)
+    await session.commit()

--- a/backend/tests/test_vehicle_services.py
+++ b/backend/tests/test_vehicle_services.py
@@ -1,0 +1,218 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.vehicle import FuelType, VehicleStatus, VehicleType
+from app.schemas import VehicleCreate, VehicleUpdate
+from app.services import (
+    create_vehicle,
+    delete_vehicle,
+    get_vehicle_by_id,
+    list_vehicles,
+    update_vehicle,
+    update_vehicle_status,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_vehicle(async_session: AsyncSession) -> None:
+    vehicle_in = VehicleCreate(
+        registration_number="b 1234 xyz",
+        vehicle_type=VehicleType.SEDAN,
+        brand="Toyota",
+        model="Camry",
+        year_manufactured=2021,
+        seating_capacity=4,
+        fuel_type=FuelType.GASOLINE,
+        current_mileage=10000,
+    )
+
+    vehicle = await create_vehicle(async_session, vehicle_in)
+
+    assert vehicle.id is not None
+    assert vehicle.registration_number == "B 1234 XYZ"
+    assert vehicle.status == VehicleStatus.ACTIVE
+    assert vehicle.current_mileage == 10000
+
+
+@pytest.mark.asyncio
+async def test_create_vehicle_duplicate_registration(async_session: AsyncSession) -> None:
+    vehicle_in = VehicleCreate(
+        registration_number="B 5678 QWE",
+        vehicle_type=VehicleType.VAN,
+        brand="Hyundai",
+        model="Staria",
+        seating_capacity=7,
+        fuel_type=FuelType.DIESEL,
+    )
+
+    await create_vehicle(async_session, vehicle_in)
+
+    with pytest.raises(ValueError):
+        await create_vehicle(async_session, vehicle_in)
+
+
+@pytest.mark.asyncio
+async def test_update_vehicle(async_session: AsyncSession) -> None:
+    vehicle = await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 1111 AAA",
+            vehicle_type=VehicleType.SEDAN,
+            brand="Honda",
+            model="Accord",
+            year_manufactured=2020,
+            seating_capacity=4,
+            fuel_type=FuelType.HYBRID,
+            current_mileage=5000,
+        ),
+    )
+
+    updated = await update_vehicle(
+        async_session,
+        vehicle=vehicle,
+        vehicle_update=VehicleUpdate(
+            registration_number="B 1111 AAB",
+            brand="Honda Updated",
+            model="Accord LX",
+            seating_capacity=5,
+            current_mileage=7500,
+            status=VehicleStatus.MAINTENANCE,
+            notes="Scheduled maintenance",
+        ),
+    )
+
+    assert updated.registration_number == "B 1111 AAB"
+    assert updated.brand == "Honda Updated"
+    assert updated.model == "Accord LX"
+    assert updated.seating_capacity == 5
+    assert updated.current_mileage == 7500
+    assert updated.status == VehicleStatus.MAINTENANCE
+    assert updated.notes == "Scheduled maintenance"
+
+
+@pytest.mark.asyncio
+async def test_update_vehicle_duplicate_registration(async_session: AsyncSession) -> None:
+    existing = await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 2222 BBB",
+            vehicle_type=VehicleType.BUS,
+            brand="Mercedes",
+            model="Sprinter",
+            seating_capacity=12,
+            fuel_type=FuelType.DIESEL,
+        ),
+    )
+    target = await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 3333 CCC",
+            vehicle_type=VehicleType.PICKUP,
+            brand="Ford",
+            model="Ranger",
+            seating_capacity=4,
+            fuel_type=FuelType.DIESEL,
+        ),
+    )
+
+    with pytest.raises(ValueError):
+        await update_vehicle(
+            async_session,
+            vehicle=target,
+            vehicle_update=VehicleUpdate(registration_number=existing.registration_number),
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_vehicles_filters(async_session: AsyncSession) -> None:
+    await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 4444 DDD",
+            vehicle_type=VehicleType.SEDAN,
+            brand="Toyota",
+            model="Vios",
+            seating_capacity=4,
+            fuel_type=FuelType.GASOLINE,
+            status=VehicleStatus.ACTIVE,
+        ),
+    )
+    await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 5555 EEE",
+            vehicle_type=VehicleType.VAN,
+            brand="Kia",
+            model="Carnival",
+            seating_capacity=7,
+            fuel_type=FuelType.DIESEL,
+            status=VehicleStatus.MAINTENANCE,
+        ),
+    )
+    await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 6666 FFF",
+            vehicle_type=VehicleType.SEDAN,
+            brand="Tesla",
+            model="Model S",
+            seating_capacity=5,
+            fuel_type=FuelType.ELECTRIC,
+            status=VehicleStatus.INACTIVE,
+        ),
+    )
+
+    sedans = await list_vehicles(async_session, vehicle_type=VehicleType.SEDAN)
+    assert {vehicle.registration_number for vehicle in sedans} == {
+        "B 4444 DDD",
+        "B 6666 FFF",
+    }
+
+    maintenance = await list_vehicles(async_session, status=VehicleStatus.MAINTENANCE)
+    assert [vehicle.registration_number for vehicle in maintenance] == ["B 5555 EEE"]
+
+    search_results = await list_vehicles(async_session, search="tesla")
+    assert [vehicle.registration_number for vehicle in search_results] == ["B 6666 FFF"]
+
+
+@pytest.mark.asyncio
+async def test_delete_vehicle(async_session: AsyncSession) -> None:
+    vehicle = await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 7777 GGG",
+            vehicle_type=VehicleType.SEDAN,
+            brand="Nissan",
+            model="Almera",
+            seating_capacity=4,
+            fuel_type=FuelType.GASOLINE,
+        ),
+    )
+
+    await delete_vehicle(async_session, vehicle=vehicle)
+
+    fetched = await get_vehicle_by_id(async_session, vehicle.id)
+    assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_update_vehicle_status(async_session: AsyncSession) -> None:
+    vehicle = await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 8888 HHH",
+            vehicle_type=VehicleType.VAN,
+            brand="Toyota",
+            model="HiAce",
+            seating_capacity=10,
+            fuel_type=FuelType.DIESEL,
+        ),
+    )
+
+    updated = await update_vehicle_status(
+        async_session,
+        vehicle=vehicle,
+        status=VehicleStatus.MAINTENANCE,
+    )
+
+    assert updated.status == VehicleStatus.MAINTENANCE


### PR DESCRIPTION
## Summary
- add vehicle validation schemas and expose them through the shared schema module
- implement vehicle services, API endpoints, and router wiring for CRUD and status updates
- expand vehicle model enum mappings and cover the service layer with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8fd7e293883289ccd289c49836a50