### PR TITLE
Implement booking request CRUD operations

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -4,7 +4,7 @@ API v1 router
 
 from fastapi import APIRouter
 
-from app.api.api_v1.endpoints import auth, drivers, health, users, vehicles
+from app.api.api_v1.endpoints import auth, bookings, drivers, health, users, vehicles
 
 api_router = APIRouter()
 
@@ -14,3 +14,4 @@ api_router.include_router(auth.router, prefix="/auth", tags=["authentication"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(vehicles.router, prefix="/vehicles", tags=["vehicles"])
 api_router.include_router(drivers.router, prefix="/drivers", tags=["drivers"])
+api_router.include_router(bookings.router, prefix="/bookings", tags=["bookings"])

--- a/backend/app/api/api_v1/endpoints/bookings.py
+++ b/backend/app/api/api_v1/endpoints/bookings.py
@@ -1,0 +1,259 @@
+"""Booking request management API endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import RoleBasedAccess, get_current_user
+from app.core.config import settings
+from app.db import get_async_session
+from app.models.booking import BookingRequest, BookingStatus, VehiclePreference
+from app.models.user import User, UserRole
+from app.schemas import (
+    BookingRequestCreate,
+    BookingRequestRead,
+    BookingRequestUpdate,
+    BookingStatusUpdate,
+)
+from app.services import (
+    create_booking_request,
+    delete_booking_request,
+    get_booking_request_by_id,
+    list_booking_requests,
+    transition_booking_status,
+    update_booking_request,
+)
+
+router = APIRouter()
+
+_MANAGEMENT_ROLES = (UserRole.MANAGER, UserRole.FLEET_ADMIN)
+_manage_bookings = RoleBasedAccess(_MANAGEMENT_ROLES)
+
+
+def _is_management(user: User) -> bool:
+    return user.role in _MANAGEMENT_ROLES
+
+
+def _ensure_can_access(booking: BookingRequest, user: User) -> None:
+    if booking.requester_id != user.id and not _is_management(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions to access this booking",
+        )
+
+
+@router.post("/", response_model=BookingRequestRead, status_code=status.HTTP_201_CREATED)
+async def create_booking(
+    booking_in: BookingRequestCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> BookingRequestRead:
+    """Create a new booking request for the authenticated user."""
+
+    target_requester_id = booking_in.requester_id or current_user.id
+    if (
+        booking_in.requester_id is not None
+        and booking_in.requester_id != current_user.id
+        and not _is_management(current_user)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions to create bookings for other users",
+        )
+
+    payload = booking_in.model_copy(update={"requester_id": target_requester_id})
+
+    try:
+        booking = await create_booking_request(session, payload)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return booking
+
+
+@router.get("/", response_model=list[BookingRequestRead])
+async def list_bookings(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(
+        default=settings.DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=settings.MAX_PAGE_SIZE,
+    ),
+    status: Optional[BookingStatus] = None,
+    requester_id: Optional[int] = Query(default=None, ge=1),
+    department: Optional[str] = Query(default=None, min_length=1, max_length=100),
+    vehicle_preference: Optional[VehiclePreference] = None,
+    start_from: Optional[datetime] = None,
+    start_to: Optional[datetime] = None,
+    search: Optional[str] = Query(default=None, min_length=1),
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_bookings),
+) -> list[BookingRequestRead]:
+    """List booking requests with optional filters. Restricted to management roles."""
+
+    department_filter = department.strip() if department else None
+    search_term = search.strip() if search else None
+
+    return await list_booking_requests(
+        session,
+        skip=skip,
+        limit=limit,
+        status=status,
+        requester_id=requester_id,
+        department=department_filter,
+        vehicle_preference=vehicle_preference,
+        start_from=start_from,
+        start_to=start_to,
+        search=search_term,
+    )
+
+
+@router.get("/me", response_model=list[BookingRequestRead])
+async def list_own_bookings(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(
+        default=settings.DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=settings.MAX_PAGE_SIZE,
+    ),
+    status: Optional[BookingStatus] = None,
+    start_from: Optional[datetime] = None,
+    start_to: Optional[datetime] = None,
+    search: Optional[str] = Query(default=None, min_length=1),
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> list[BookingRequestRead]:
+    """List the authenticated user's booking requests."""
+
+    search_term = search.strip() if search else None
+
+    return await list_booking_requests(
+        session,
+        skip=skip,
+        limit=limit,
+        status=status,
+        requester_id=current_user.id,
+        start_from=start_from,
+        start_to=start_to,
+        search=search_term,
+    )
+
+
+@router.get("/{booking_id}", response_model=BookingRequestRead)
+async def get_booking_detail(
+    booking_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> BookingRequestRead:
+    """Retrieve a single booking request."""
+
+    booking = await get_booking_request_by_id(session, booking_id)
+    if booking is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking not found")
+
+    _ensure_can_access(booking, current_user)
+    return booking
+
+
+@router.patch("/{booking_id}", response_model=BookingRequestRead)
+async def update_booking(
+    booking_id: int,
+    booking_update: BookingRequestUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> BookingRequestRead:
+    """Update details of an existing booking request."""
+
+    booking = await get_booking_request_by_id(session, booking_id)
+    if booking is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking not found")
+
+    _ensure_can_access(booking, current_user)
+
+    try:
+        return await update_booking_request(
+            session, booking_request=booking, booking_update=booking_update
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.delete("/{booking_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_booking(
+    booking_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    """Delete a booking request."""
+
+    booking = await get_booking_request_by_id(session, booking_id)
+    if booking is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking not found")
+
+    _ensure_can_access(booking, current_user)
+
+    try:
+        await delete_booking_request(session, booking_request=booking)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.patch("/{booking_id}/status", response_model=BookingRequestRead)
+async def update_booking_status(
+    booking_id: int,
+    status_update: BookingStatusUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> BookingRequestRead:
+    """Update the workflow status of a booking request."""
+
+    booking = await get_booking_request_by_id(session, booking_id)
+    if booking is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking not found")
+
+    new_status = status_update.status
+
+    is_management = _is_management(current_user)
+    is_owner = booking.requester_id == current_user.id
+
+    if new_status == BookingStatus.REQUESTED and not (is_owner or is_management):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the requester or management can submit a booking",
+        )
+
+    if new_status == BookingStatus.CANCELLED and not (is_owner or is_management):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the requester or management can cancel a booking",
+        )
+
+    if new_status not in {BookingStatus.REQUESTED, BookingStatus.CANCELLED} and not is_management:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only management can perform this status update",
+        )
+
+    try:
+        return await transition_booking_status(
+            session, booking_request=booking, new_status=new_status
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -32,6 +32,12 @@ from .vehicle import (
     VehicleStatusUpdate,
     VehicleUpdate,
 )
+from .booking import (
+    BookingRequestCreate,
+    BookingRequestRead,
+    BookingRequestUpdate,
+    BookingStatusUpdate,
+)
 
 __all__ = [
     "LoginRequest",
@@ -58,4 +64,8 @@ __all__ = [
     "VehicleRead",
     "VehicleStatusUpdate",
     "VehicleUpdate",
+    "BookingRequestCreate",
+    "BookingRequestRead",
+    "BookingRequestUpdate",
+    "BookingStatusUpdate",
 ]

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -1,0 +1,191 @@
+"""Pydantic schemas for booking request operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.models.booking import BookingStatus, VehiclePreference
+
+
+def _normalise_required_text(value: str, field_display: str) -> str:
+    """Strip and validate that *value* is not empty."""
+
+    normalised = " ".join(value.split())
+    if not normalised:
+        raise ValueError(f"{field_display} must not be empty")
+    return normalised
+
+
+def _normalise_optional_text(value: Optional[str]) -> Optional[str]:
+    """Strip whitespace and return ``None`` for empty strings."""
+
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _validate_datetime_window(start: datetime, end: datetime) -> None:
+    """Ensure the booking window represented by *start* and *end* is valid."""
+
+    if start >= end:
+        msg = "End datetime must be after the start datetime"
+        raise ValueError(msg)
+
+    if (start.tzinfo is None) != (end.tzinfo is None):
+        msg = "Start and end datetimes must both be naive or both timezone-aware"
+        raise ValueError(msg)
+
+
+class BookingRequestBase(BaseModel):
+    """Fields shared by booking request create and read schemas."""
+
+    department: Optional[str] = Field(default=None, max_length=100)
+    purpose: str = Field(..., max_length=500)
+    passenger_count: int = Field(1, ge=1, le=100)
+    start_datetime: datetime
+    end_datetime: datetime
+    pickup_location: str = Field(..., max_length=500)
+    dropoff_location: str = Field(..., max_length=500)
+    vehicle_preference: VehiclePreference = VehiclePreference.ANY
+    special_requirements: Optional[str] = Field(default=None, max_length=2000)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("purpose")
+    @classmethod
+    def _normalise_purpose(cls, value: str) -> str:
+        return _normalise_required_text(value, "Purpose")
+
+    @field_validator("pickup_location")
+    @classmethod
+    def _normalise_pickup(cls, value: str) -> str:
+        return _normalise_required_text(value, "Pickup location")
+
+    @field_validator("dropoff_location")
+    @classmethod
+    def _normalise_dropoff(cls, value: str) -> str:
+        return _normalise_required_text(value, "Drop-off location")
+
+    @field_validator("department")
+    @classmethod
+    def _normalise_department(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+    @field_validator("special_requirements")
+    @classmethod
+    def _normalise_special_requirements(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+    @model_validator(mode="after")
+    def _validate_window(self) -> "BookingRequestBase":
+        _validate_datetime_window(self.start_datetime, self.end_datetime)
+        return self
+
+
+class BookingRequestCreate(BookingRequestBase):
+    """Schema for creating booking requests."""
+
+    requester_id: Optional[int] = Field(default=None, ge=1)
+    status: BookingStatus = BookingStatus.DRAFT
+
+    @model_validator(mode="after")
+    def _validate_initial_status(self) -> "BookingRequestCreate":
+        if self.status not in {BookingStatus.DRAFT, BookingStatus.REQUESTED}:
+            msg = "Booking requests can only be created in DRAFT or REQUESTED status"
+            raise ValueError(msg)
+        return self
+
+
+class BookingRequestUpdate(BaseModel):
+    """Schema for updating booking request details."""
+
+    department: Optional[str] = Field(default=None, max_length=100)
+    purpose: Optional[str] = Field(default=None, max_length=500)
+    passenger_count: Optional[int] = Field(default=None, ge=1, le=100)
+    start_datetime: Optional[datetime] = None
+    end_datetime: Optional[datetime] = None
+    pickup_location: Optional[str] = Field(default=None, max_length=500)
+    dropoff_location: Optional[str] = Field(default=None, max_length=500)
+    vehicle_preference: Optional[VehiclePreference] = None
+    special_requirements: Optional[str] = Field(default=None, max_length=2000)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("department")
+    @classmethod
+    def _normalise_department(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+    @field_validator("purpose")
+    @classmethod
+    def _normalise_purpose(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        if value is None:
+            return None
+        return _normalise_required_text(value, "Purpose")
+
+    @field_validator("pickup_location")
+    @classmethod
+    def _normalise_pickup(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        if value is None:
+            return None
+        return _normalise_required_text(value, "Pickup location")
+
+    @field_validator("dropoff_location")
+    @classmethod
+    def _normalise_dropoff(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        if value is None:
+            return None
+        return _normalise_required_text(value, "Drop-off location")
+
+    @field_validator("special_requirements")
+    @classmethod
+    def _normalise_special_requirements(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+    @model_validator(mode="after")
+    def _validate_partial_window(self) -> "BookingRequestUpdate":
+        start = self.start_datetime
+        end = self.end_datetime
+        if start is not None and end is not None:
+            _validate_datetime_window(start, end)
+        return self
+
+
+class BookingStatusUpdate(BaseModel):
+    """Schema for updating the booking request status."""
+
+    status: BookingStatus
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BookingRequestRead(BookingRequestBase):
+    """Response schema for booking requests."""
+
+    id: int
+    requester_id: int
+    status: BookingStatus
+    submitted_at: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -23,6 +23,14 @@ from .vehicle import (
     update_vehicle,
     update_vehicle_status,
 )
+from .booking import (
+    create_booking_request,
+    delete_booking_request,
+    get_booking_request_by_id,
+    list_booking_requests,
+    transition_booking_status,
+    update_booking_request,
+)
 from .driver import (
     create_driver,
     delete_driver,
@@ -60,6 +68,12 @@ __all__ = [
     "store_vehicle_document",
     "update_vehicle",
     "update_vehicle_status",
+    "create_booking_request",
+    "delete_booking_request",
+    "get_booking_request_by_id",
+    "list_booking_requests",
+    "transition_booking_status",
+    "update_booking_request",
     "create_driver",
     "delete_driver",
     "get_driver_conflicting_assignments",

--- a/backend/app/services/booking.py
+++ b/backend/app/services/booking.py
@@ -1,0 +1,227 @@
+"""Service layer for booking request management."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Select, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.booking import BookingRequest, BookingStatus, VehiclePreference
+from app.schemas.booking import BookingRequestCreate, BookingRequestUpdate
+
+_EDITABLE_STATUSES: frozenset[BookingStatus] = frozenset(
+    {BookingStatus.DRAFT, BookingStatus.REQUESTED}
+)
+
+_ALLOWED_TRANSITIONS: dict[BookingStatus, frozenset[BookingStatus]] = {
+    BookingStatus.DRAFT: frozenset({BookingStatus.REQUESTED, BookingStatus.CANCELLED}),
+    BookingStatus.REQUESTED: frozenset(
+        {BookingStatus.APPROVED, BookingStatus.REJECTED, BookingStatus.CANCELLED}
+    ),
+    BookingStatus.APPROVED: frozenset({BookingStatus.ASSIGNED, BookingStatus.CANCELLED}),
+    BookingStatus.ASSIGNED: frozenset({BookingStatus.IN_PROGRESS, BookingStatus.CANCELLED}),
+    BookingStatus.IN_PROGRESS: frozenset({BookingStatus.COMPLETED, BookingStatus.CANCELLED}),
+    BookingStatus.REJECTED: frozenset(),
+    BookingStatus.COMPLETED: frozenset(),
+    BookingStatus.CANCELLED: frozenset(),
+}
+
+
+def _normalise_search_term(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    trimmed = " ".join(value.split())
+    return trimmed or None
+
+
+def _validate_window(start: datetime, end: datetime) -> None:
+    if start >= end:
+        msg = "End datetime must be after the start datetime"
+        raise ValueError(msg)
+
+    if (start.tzinfo is None) != (end.tzinfo is None):
+        msg = "Start and end datetimes must both be naive or both timezone-aware"
+        raise ValueError(msg)
+
+
+async def get_booking_request_by_id(
+    session: AsyncSession, booking_request_id: int
+) -> Optional[BookingRequest]:
+    """Return the booking request with the supplied identifier, if present."""
+
+    stmt: Select[tuple[BookingRequest]] = select(BookingRequest).where(
+        BookingRequest.id == booking_request_id
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_booking_requests(
+    session: AsyncSession,
+    *,
+    skip: int = 0,
+    limit: Optional[int] = None,
+    status: Optional[BookingStatus] = None,
+    requester_id: Optional[int] = None,
+    department: Optional[str] = None,
+    vehicle_preference: Optional[VehiclePreference] = None,
+    start_from: Optional[datetime] = None,
+    start_to: Optional[datetime] = None,
+    search: Optional[str] = None,
+) -> list[BookingRequest]:
+    """Return booking requests filtered by the supplied parameters."""
+
+    stmt: Select[tuple[BookingRequest]] = select(BookingRequest).order_by(
+        BookingRequest.start_datetime, BookingRequest.id
+    )
+
+    if status is not None:
+        stmt = stmt.where(BookingRequest.status == status)
+
+    if requester_id is not None:
+        stmt = stmt.where(BookingRequest.requester_id == requester_id)
+
+    if department:
+        stmt = stmt.where(func.lower(BookingRequest.department) == department.lower())
+
+    if vehicle_preference is not None:
+        stmt = stmt.where(BookingRequest.vehicle_preference == vehicle_preference)
+
+    if start_from is not None:
+        stmt = stmt.where(BookingRequest.start_datetime >= start_from)
+
+    if start_to is not None:
+        stmt = stmt.where(BookingRequest.start_datetime <= start_to)
+
+    search_term = _normalise_search_term(search)
+    if search_term:
+        pattern = f"%{search_term.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(BookingRequest.purpose).like(pattern),
+                func.lower(BookingRequest.pickup_location).like(pattern),
+                func.lower(BookingRequest.dropoff_location).like(pattern),
+            )
+        )
+
+    if skip:
+        stmt = stmt.offset(skip)
+
+    if limit is not None:
+        stmt = stmt.limit(limit)
+
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def create_booking_request(
+    session: AsyncSession, booking_in: BookingRequestCreate
+) -> BookingRequest:
+    """Create a new booking request after validating business rules."""
+
+    data = booking_in.model_dump()
+    requester_id = data.pop("requester_id")
+    if requester_id is None:
+        msg = "requester_id must be provided"
+        raise ValueError(msg)
+
+    start = data["start_datetime"]
+    end = data["end_datetime"]
+    _validate_window(start, end)
+
+    status = data.pop("status", BookingStatus.DRAFT)
+    booking = BookingRequest(requester_id=requester_id, status=status, **data)
+
+    if status == BookingStatus.REQUESTED:
+        booking.submitted_at = datetime.now(timezone.utc)
+
+    session.add(booking)
+    await session.commit()
+    await session.refresh(booking)
+    return booking
+
+
+async def update_booking_request(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    booking_update: BookingRequestUpdate,
+) -> BookingRequest:
+    """Update mutable fields on an existing booking request."""
+
+    if booking_request.status not in _EDITABLE_STATUSES:
+        msg = "Only draft or requested bookings can be modified"
+        raise ValueError(msg)
+
+    data = booking_update.model_dump(exclude_unset=True)
+
+    if "start_datetime" in data or "end_datetime" in data:
+        new_start = data.get("start_datetime", booking_request.start_datetime)
+        new_end = data.get("end_datetime", booking_request.end_datetime)
+        _validate_window(new_start, new_end)
+        booking_request.start_datetime = new_start
+        booking_request.end_datetime = new_end
+        data.pop("start_datetime", None)
+        data.pop("end_datetime", None)
+
+    for field, value in data.items():
+        setattr(booking_request, field, value)
+
+    await session.commit()
+    await session.refresh(booking_request)
+    return booking_request
+
+
+async def delete_booking_request(
+    session: AsyncSession, *, booking_request: BookingRequest
+) -> None:
+    """Delete the provided booking request if it is still editable."""
+
+    if booking_request.status not in _EDITABLE_STATUSES:
+        msg = "Only draft or requested bookings can be deleted"
+        raise ValueError(msg)
+
+    await session.delete(booking_request)
+    await session.commit()
+
+
+async def transition_booking_status(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    new_status: BookingStatus,
+) -> BookingRequest:
+    """Transition the booking request to *new_status* following workflow rules."""
+
+    current_status = booking_request.status
+    if new_status == current_status:
+        return booking_request
+
+    allowed = _ALLOWED_TRANSITIONS.get(current_status, frozenset())
+    if new_status not in allowed:
+        msg = (
+            f"Cannot transition booking from {current_status} to {new_status}"
+        )
+        raise ValueError(msg)
+
+    booking_request.status = new_status
+
+    if new_status == BookingStatus.REQUESTED and booking_request.submitted_at is None:
+        booking_request.submitted_at = datetime.now(timezone.utc)
+
+    await session.commit()
+    await session.refresh(booking_request)
+    return booking_request
+
+
+__all__ = [
+    "create_booking_request",
+    "delete_booking_request",
+    "get_booking_request_by_id",
+    "list_booking_requests",
+    "transition_booking_status",
+    "update_booking_request",
+]
+

--- a/backend/tests/test_booking_services.py
+++ b/backend/tests/test_booking_services.py
@@ -1,0 +1,390 @@
+"""Unit tests for booking request service functions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.booking import BookingStatus, VehiclePreference
+from app.models.user import UserRole
+from app.schemas import (
+    BookingRequestCreate,
+    BookingRequestUpdate,
+    UserCreate,
+)
+from app.services import (
+    create_booking_request,
+    create_user,
+    delete_booking_request,
+    get_booking_request_by_id,
+    list_booking_requests,
+    transition_booking_status,
+    update_booking_request,
+)
+
+
+def _future_window(hours_from_now: int = 1, duration_hours: int = 2) -> tuple[datetime, datetime]:
+    start = datetime.now(timezone.utc) + timedelta(hours=hours_from_now)
+    end = start + timedelta(hours=duration_hours)
+    return start, end
+
+
+@pytest.mark.asyncio
+async def test_create_booking_request(async_session: AsyncSession) -> None:
+    user = await create_user(
+        async_session,
+        UserCreate(
+            username="requester1",
+            email="requester1@example.com",
+            full_name="Requester One",
+            department="Sales",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+
+    start, end = _future_window()
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=user.id,
+            department="  Finance  ",
+            purpose="  Team meeting planning  ",
+            passenger_count=3,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="  Headquarters  ",
+            dropoff_location=" Branch Office ",
+            vehicle_preference=VehiclePreference.VAN,
+            special_requirements="  Child seat  ",
+        ),
+    )
+
+    assert booking.id is not None
+    assert booking.requester_id == user.id
+    assert booking.department == "Finance"
+    assert booking.purpose == "Team meeting planning"
+    assert booking.pickup_location == "Headquarters"
+    assert booking.dropoff_location == "Branch Office"
+    assert booking.vehicle_preference == VehiclePreference.VAN
+    assert booking.status == BookingStatus.DRAFT
+    assert booking.submitted_at is None
+
+
+@pytest.mark.asyncio
+async def test_create_booking_request_submitted(async_session: AsyncSession) -> None:
+    user = await create_user(
+        async_session,
+        UserCreate(
+            username="requester2",
+            email="requester2@example.com",
+            full_name="Requester Two",
+            department="Operations",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+
+    start, end = _future_window(hours_from_now=2)
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=user.id,
+            purpose="Client visit",
+            passenger_count=2,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="Office",
+            dropoff_location="Airport",
+            status=BookingStatus.REQUESTED,
+        ),
+    )
+
+    assert booking.status == BookingStatus.REQUESTED
+    assert booking.submitted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_create_booking_request_requires_requester(async_session: AsyncSession) -> None:
+    start, end = _future_window()
+
+    with pytest.raises(ValueError):
+        await create_booking_request(
+            async_session,
+            BookingRequestCreate(
+                purpose="Training",
+                passenger_count=4,
+                start_datetime=start,
+                end_datetime=end,
+                pickup_location="HQ",
+                dropoff_location="Training Center",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_booking_request(async_session: AsyncSession) -> None:
+    user = await create_user(
+        async_session,
+        UserCreate(
+            username="requester3",
+            email="requester3@example.com",
+            full_name="Requester Three",
+            department="Finance",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+
+    start, end = _future_window()
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=user.id,
+            department="Finance",
+            purpose="Budget review",
+            passenger_count=1,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="Main HQ",
+            dropoff_location="City Hall",
+            special_requirements=None,
+        ),
+    )
+
+    new_start = start + timedelta(hours=1)
+    new_end = end + timedelta(hours=1)
+
+    updated = await update_booking_request(
+        async_session,
+        booking_request=booking,
+        booking_update=BookingRequestUpdate(
+            department="  Operations  ",
+            passenger_count=4,
+            start_datetime=new_start,
+            end_datetime=new_end,
+            pickup_location=" Secondary Office  ",
+            special_requirements="  VIP guest  ",
+        ),
+    )
+
+    assert updated.department == "Operations"
+    assert updated.passenger_count == 4
+    assert updated.start_datetime == new_start.replace(tzinfo=None)
+    assert updated.end_datetime == new_end.replace(tzinfo=None)
+    assert updated.pickup_location == "Secondary Office"
+    assert updated.special_requirements == "VIP guest"
+
+
+@pytest.mark.asyncio
+async def test_update_booking_request_disallowed(async_session: AsyncSession) -> None:
+    user = await create_user(
+        async_session,
+        UserCreate(
+            username="requester4",
+            email="requester4@example.com",
+            full_name="Requester Four",
+            department="Engineering",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+
+    start, end = _future_window()
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=user.id,
+            purpose="Site inspection",
+            passenger_count=2,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="Plant",
+            dropoff_location="Warehouse",
+        ),
+    )
+
+    await transition_booking_status(
+        async_session, booking_request=booking, new_status=BookingStatus.CANCELLED
+    )
+
+    with pytest.raises(ValueError):
+        await update_booking_request(
+            async_session,
+            booking_request=booking,
+            booking_update=BookingRequestUpdate(purpose="Updated purpose"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_transition_booking_status_workflow(async_session: AsyncSession) -> None:
+    user = await create_user(
+        async_session,
+        UserCreate(
+            username="requester5",
+            email="requester5@example.com",
+            full_name="Requester Five",
+            department="Logistics",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+
+    start, end = _future_window()
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=user.id,
+            purpose="Shuttle",
+            passenger_count=5,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="Office",
+            dropoff_location="Convention Center",
+        ),
+    )
+
+    booking = await transition_booking_status(
+        async_session, booking_request=booking, new_status=BookingStatus.REQUESTED
+    )
+    assert booking.status == BookingStatus.REQUESTED
+    assert booking.submitted_at is not None
+
+    booking = await transition_booking_status(
+        async_session, booking_request=booking, new_status=BookingStatus.APPROVED
+    )
+    assert booking.status == BookingStatus.APPROVED
+
+    with pytest.raises(ValueError):
+        await transition_booking_status(
+            async_session, booking_request=booking, new_status=BookingStatus.COMPLETED
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_booking_requests_filters(async_session: AsyncSession) -> None:
+    requester_a = await create_user(
+        async_session,
+        UserCreate(
+            username="requester6",
+            email="requester6@example.com",
+            full_name="Requester Six",
+            department="Support",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+    requester_b = await create_user(
+        async_session,
+        UserCreate(
+            username="requester7",
+            email="requester7@example.com",
+            full_name="Requester Seven",
+            department="Support",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+
+    start1, end1 = _future_window(hours_from_now=3)
+    start2, end2 = _future_window(hours_from_now=5)
+
+    booking_a = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=requester_a.id,
+            department="Support",
+            purpose="Airport transfer",
+            passenger_count=2,
+            start_datetime=start1,
+            end_datetime=end1,
+            pickup_location="HQ",
+            dropoff_location="Airport",
+            status=BookingStatus.REQUESTED,
+        ),
+    )
+
+    booking_b = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=requester_b.id,
+            department="Support",
+            purpose="Client visit",
+            passenger_count=3,
+            start_datetime=start2,
+            end_datetime=end2,
+            pickup_location="Hotel",
+            dropoff_location="HQ",
+        ),
+    )
+
+    requested = await list_booking_requests(
+        async_session, status=BookingStatus.REQUESTED
+    )
+    assert [b.id for b in requested] == [booking_a.id]
+
+    filtered = await list_booking_requests(
+        async_session,
+        requester_id=requester_b.id,
+        search="hotel",
+    )
+    assert [b.id for b in filtered] == [booking_b.id]
+
+
+@pytest.mark.asyncio
+async def test_delete_booking_request(async_session: AsyncSession) -> None:
+    user = await create_user(
+        async_session,
+        UserCreate(
+            username="requester8",
+            email="requester8@example.com",
+            full_name="Requester Eight",
+            department="HR",
+            role=UserRole.REQUESTER,
+            password="Password123",
+        ),
+    )
+
+    start, end = _future_window()
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=user.id,
+            purpose="Orientation",
+            passenger_count=1,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="HQ",
+            dropoff_location="Training Center",
+        ),
+    )
+
+    await delete_booking_request(async_session, booking_request=booking)
+    deleted = await get_booking_request_by_id(async_session, booking.id)
+    assert deleted is None
+
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=user.id,
+            purpose="Site visit",
+            passenger_count=2,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="HQ",
+            dropoff_location="Plant",
+        ),
+    )
+
+    await transition_booking_status(
+        async_session, booking_request=booking, new_status=BookingStatus.REQUESTED
+    )
+    await transition_booking_status(
+        async_session, booking_request=booking, new_status=BookingStatus.APPROVED
+    )
+
+    with pytest.raises(ValueError):
+        await delete_booking_request(async_session, booking_request=booking)
+


### PR DESCRIPTION
## Summary
- add booking request schemas, service layer logic, and API endpoints including status workflow and filtering
- expose the booking services through the application package and router
- cover the booking workflow with dedicated service-level unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c90bdaa90883289251fb448e560d1c