### PR TITLE
Add booking assignment services and API

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -4,7 +4,15 @@ API v1 router
 
 from fastapi import APIRouter
 
-from app.api.api_v1.endpoints import auth, bookings, drivers, health, users, vehicles
+from app.api.api_v1.endpoints import (
+    assignments,
+    auth,
+    bookings,
+    drivers,
+    health,
+    users,
+    vehicles,
+)
 
 api_router = APIRouter()
 
@@ -15,3 +23,4 @@ api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(vehicles.router, prefix="/vehicles", tags=["vehicles"])
 api_router.include_router(drivers.router, prefix="/drivers", tags=["drivers"])
 api_router.include_router(bookings.router, prefix="/bookings", tags=["bookings"])
+api_router.include_router(assignments.router, prefix="/assignments", tags=["assignments"])

--- a/backend/app/api/api_v1/endpoints/assignments.py
+++ b/backend/app/api/api_v1/endpoints/assignments.py
@@ -1,0 +1,141 @@
+"""API endpoints for booking assignments."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import RoleBasedAccess
+from app.db import get_async_session
+from app.models.user import User, UserRole
+from app.schemas import (
+    AssignmentCreate,
+    AssignmentRead,
+    AssignmentSuggestionRead,
+    AssignmentUpdate,
+)
+from app.services import (
+    create_assignment,
+    get_assignment_by_booking_id,
+    get_assignment_by_id,
+    get_booking_request_by_id,
+    suggest_assignment_options,
+    update_assignment,
+)
+
+router = APIRouter()
+
+_MANAGEMENT_ROLES = (UserRole.MANAGER, UserRole.FLEET_ADMIN)
+_manage_assignments = RoleBasedAccess(_MANAGEMENT_ROLES)
+
+
+@router.get("/{assignment_id}", response_model=AssignmentRead)
+async def get_assignment_detail(
+    assignment_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_assignments),
+) -> AssignmentRead:
+    """Return the assignment identified by *assignment_id*."""
+
+    assignment = await get_assignment_by_id(session, assignment_id)
+    if assignment is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assignment not found",
+        )
+    return assignment
+
+
+@router.get("/by-booking/{booking_id}", response_model=AssignmentRead)
+async def get_booking_assignment(
+    booking_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_assignments),
+) -> AssignmentRead:
+    """Return the assignment linked to the supplied booking, if any."""
+
+    assignment = await get_assignment_by_booking_id(session, booking_id)
+    if assignment is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assignment not found",
+        )
+    return assignment
+
+
+@router.get(
+    "/by-booking/{booking_id}/suggestions",
+    response_model=list[AssignmentSuggestionRead],
+)
+async def list_assignment_suggestions(
+    booking_id: int,
+    limit: int = Query(5, ge=1, le=20),
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_assignments),
+) -> list[AssignmentSuggestionRead]:
+    """Return suggested resource allocations for the given booking."""
+
+    booking = await get_booking_request_by_id(session, booking_id)
+    if booking is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Booking not found",
+        )
+
+    return await suggest_assignment_options(session, booking_request=booking, limit=limit)
+
+
+@router.post("/", response_model=AssignmentRead, status_code=status.HTTP_201_CREATED)
+async def create_booking_assignment(
+    assignment_in: AssignmentCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(_manage_assignments),
+) -> AssignmentRead:
+    """Create a new resource assignment for a booking."""
+
+    try:
+        return await create_assignment(session, assignment_in, assigned_by=current_user)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.patch("/{assignment_id}", response_model=AssignmentRead)
+async def update_booking_assignment(
+    assignment_id: int,
+    assignment_update: AssignmentUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(_manage_assignments),
+) -> AssignmentRead:
+    """Reassign resources for an existing booking."""
+
+    assignment = await get_assignment_by_id(session, assignment_id)
+    if assignment is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assignment not found",
+        )
+
+    try:
+        return await update_assignment(
+            session,
+            assignment=assignment,
+            assignment_update=assignment_update,
+            assigned_by=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+__all__ = [
+    "create_booking_assignment",
+    "get_assignment_detail",
+    "get_booking_assignment",
+    "list_assignment_suggestions",
+    "update_booking_assignment",
+]

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -1,31 +1,49 @@
-"""Assignment model for vehicle and driver allocation"""
+"""Assignment model for vehicle and driver allocation."""
 
-from typing import Optional
 from datetime import datetime
-from sqlalchemy import String, Integer, DateTime, Text, ForeignKey
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
 
 from .base import Base
 
 
 class Assignment(Base):
-    """Assignment model for vehicle and driver allocation to booking requests"""
-    
+    """Assignment model for vehicle and driver allocation to booking requests."""
+
     __tablename__ = "assignments"
-    
+
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    booking_request_id: Mapped[int] = mapped_column(ForeignKey("booking_requests.id", ondelete="CASCADE"), unique=True, nullable=False, index=True)
-    vehicle_id: Mapped[int] = mapped_column(ForeignKey("vehicles.id"), nullable=False, index=True)
-    driver_id: Mapped[int] = mapped_column(ForeignKey("drivers.id"), nullable=False, index=True)
-    assigned_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
-    assigned_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default="CURRENT_TIMESTAMP")
+    booking_request_id: Mapped[int] = mapped_column(
+        ForeignKey("booking_requests.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    vehicle_id: Mapped[int] = mapped_column(
+        ForeignKey("vehicles.id"), nullable=False, index=True
+    )
+    driver_id: Mapped[int] = mapped_column(
+        ForeignKey("drivers.id"), nullable=False, index=True
+    )
+    assigned_by: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), nullable=False, index=True
+    )
+    assigned_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    
+
     # Relationships
     booking_request = relationship("BookingRequest", back_populates="assignment")
     vehicle = relationship("Vehicle", back_populates="assignments")
     driver = relationship("Driver", back_populates="assignments")
     assigned_by_user = relationship("User", back_populates="assignments_created")
-    
+
     def __repr__(self) -> str:
-        return f"<Assignment(id={self.id}, booking_id={self.booking_request_id}, vehicle_id={self.vehicle_id}, driver_id={self.driver_id})>"
+        return (
+            "<Assignment(id={self.id}, booking_id={self.booking_request_id}, "
+            "vehicle_id={self.vehicle_id}, driver_id={self.driver_id})>"
+        )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -45,6 +45,17 @@ from .approval import (
     BookingApprovalResponse,
     PendingApprovalNotificationRead,
 )
+from .assignment import (
+    AssignmentCreate,
+    AssignmentDriverSuggestion,
+    AssignmentDriverSuggestionData,
+    AssignmentRead,
+    AssignmentSuggestionData,
+    AssignmentSuggestionRead,
+    AssignmentUpdate,
+    AssignmentVehicleSuggestion,
+    AssignmentVehicleSuggestionData,
+)
 
 __all__ = [
     "LoginRequest",
@@ -80,4 +91,13 @@ __all__ = [
     "ApprovalRead",
     "BookingApprovalResponse",
     "PendingApprovalNotificationRead",
+    "AssignmentCreate",
+    "AssignmentDriverSuggestion",
+    "AssignmentDriverSuggestionData",
+    "AssignmentRead",
+    "AssignmentSuggestionData",
+    "AssignmentSuggestionRead",
+    "AssignmentUpdate",
+    "AssignmentVehicleSuggestion",
+    "AssignmentVehicleSuggestionData",
 ]

--- a/backend/app/schemas/assignment.py
+++ b/backend/app/schemas/assignment.py
@@ -1,0 +1,151 @@
+"""Schemas and helper data structures for booking assignments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from app.models.vehicle import VehicleType
+
+
+def _normalise_optional_text(value: Optional[str]) -> Optional[str]:
+    """Return a stripped version of ``value`` or ``None`` for empty strings."""
+
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+@dataclass(slots=True)
+class AssignmentVehicleSuggestionData:
+    """Lightweight representation of a suggested vehicle."""
+
+    id: int
+    registration_number: str
+    vehicle_type: VehicleType
+    seating_capacity: int
+    matches_preference: bool
+    spare_seats: int
+
+
+@dataclass(slots=True)
+class AssignmentDriverSuggestionData:
+    """Lightweight representation of a suggested driver."""
+
+    id: int
+    full_name: str
+    license_number: str
+
+
+@dataclass(slots=True)
+class AssignmentSuggestionData:
+    """Pairing of a vehicle and driver suggestion."""
+
+    vehicle: AssignmentVehicleSuggestionData
+    driver: AssignmentDriverSuggestionData
+    score: int
+    reasons: list[str]
+
+
+class AssignmentCreate(BaseModel):
+    """Payload for creating a new assignment."""
+
+    booking_request_id: int = Field(..., ge=1)
+    vehicle_id: Optional[int] = Field(default=None, ge=1)
+    driver_id: Optional[int] = Field(default=None, ge=1)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    auto_assign: bool = True
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("notes")
+    @classmethod
+    def _normalise_notes(cls, value: Optional[str]) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+    @model_validator(mode="after")
+    def _validate_manual_override(self) -> "AssignmentCreate":
+        if not self.auto_assign and (self.vehicle_id is None or self.driver_id is None):
+            msg = "Manual assignment requires both vehicle_id and driver_id"
+            raise ValueError(msg)
+        return self
+
+
+class AssignmentUpdate(BaseModel):
+    """Payload for updating an existing assignment."""
+
+    vehicle_id: Optional[int] = Field(default=None, ge=1)
+    driver_id: Optional[int] = Field(default=None, ge=1)
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    auto_assign: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("notes")
+    @classmethod
+    def _normalise_notes(cls, value: Optional[str]) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+
+class AssignmentRead(BaseModel):
+    """Read model for persisted assignments."""
+
+    id: int
+    booking_request_id: int
+    vehicle_id: int
+    driver_id: int
+    assigned_by: int
+    assigned_at: datetime
+    notes: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AssignmentVehicleSuggestion(BaseModel):
+    """Detailed information about a suggested vehicle."""
+
+    id: int
+    registration_number: str
+    vehicle_type: VehicleType
+    seating_capacity: int
+    matches_preference: bool
+    spare_seats: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AssignmentDriverSuggestion(BaseModel):
+    """Detailed information about a suggested driver."""
+
+    id: int
+    full_name: str
+    license_number: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AssignmentSuggestionRead(BaseModel):
+    """Response model for assignment suggestions."""
+
+    vehicle: AssignmentVehicleSuggestion
+    driver: AssignmentDriverSuggestion
+    score: int
+    reasons: list[str]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+__all__ = [
+    "AssignmentCreate",
+    "AssignmentDriverSuggestion",
+    "AssignmentDriverSuggestionData",
+    "AssignmentRead",
+    "AssignmentSuggestionData",
+    "AssignmentSuggestionRead",
+    "AssignmentUpdate",
+    "AssignmentVehicleSuggestion",
+    "AssignmentVehicleSuggestionData",
+]

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -59,6 +59,13 @@ from .driver import (
     update_driver_availability,
     update_driver_status,
 )
+from .assignment import (
+    create_assignment,
+    get_assignment_by_booking_id,
+    get_assignment_by_id,
+    suggest_assignment_options,
+    update_assignment,
+)
 
 __all__ = [
     "change_user_password",
@@ -110,4 +117,9 @@ __all__ = [
     "update_driver",
     "update_driver_availability",
     "update_driver_status",
+    "create_assignment",
+    "get_assignment_by_booking_id",
+    "get_assignment_by_id",
+    "suggest_assignment_options",
+    "update_assignment",
 ]

--- a/backend/app/services/assignment.py
+++ b/backend/app/services/assignment.py
@@ -1,0 +1,482 @@
+"""Service layer for booking resource assignments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Optional, Sequence
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.assignment import Assignment
+from app.models.booking import BookingRequest, BookingStatus, VehiclePreference
+from app.models.driver import Driver, DriverStatus
+from app.models.user import User
+from app.models.vehicle import Vehicle, VehicleStatus, VehicleType
+from app.schemas.assignment import (
+    AssignmentCreate,
+    AssignmentDriverSuggestionData,
+    AssignmentSuggestionData,
+    AssignmentUpdate,
+    AssignmentVehicleSuggestionData,
+)
+from app.services.driver import ensure_driver_available, get_driver_by_id
+from app.services.vehicle import get_vehicle_by_id, is_vehicle_available
+
+
+@dataclass(slots=True)
+class _VehicleCandidate:
+    vehicle: Vehicle
+    suggestion: AssignmentVehicleSuggestionData
+    score: int
+    reasons: list[str]
+
+
+@dataclass(slots=True)
+class _DriverCandidate:
+    driver: Driver
+    suggestion: AssignmentDriverSuggestionData
+    score: int
+    reasons: list[str]
+
+
+async def get_assignment_by_id(
+    session: AsyncSession, assignment_id: int
+) -> Optional[Assignment]:
+    """Return the assignment identified by *assignment_id*, if any."""
+
+    result = await session.execute(
+        select(Assignment).where(Assignment.id == assignment_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_assignment_by_booking_id(
+    session: AsyncSession, booking_request_id: int
+) -> Optional[Assignment]:
+    """Return the assignment attached to the supplied booking request."""
+
+    result = await session.execute(
+        select(Assignment).where(Assignment.booking_request_id == booking_request_id)
+    )
+    return result.scalar_one_or_none()
+
+
+def _matches_vehicle_preference(
+    vehicle_type: VehicleType, preference: VehiclePreference
+) -> bool:
+    if preference == VehiclePreference.ANY:
+        return True
+    return vehicle_type.value == preference.value
+
+
+async def _collect_vehicle_candidates(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    limit: int,
+    exclude_vehicle_ids: Iterable[int] = (),
+    exclude_booking_id: Optional[int] = None,
+) -> list[_VehicleCandidate]:
+    stmt: Select[tuple[Vehicle]] = select(Vehicle).where(
+        Vehicle.status == VehicleStatus.ACTIVE,
+        Vehicle.seating_capacity >= booking_request.passenger_count,
+    )
+
+    excluded = frozenset(exclude_vehicle_ids)
+    if excluded:
+        stmt = stmt.where(Vehicle.id.notin_(tuple(excluded)))
+
+    stmt = stmt.order_by(Vehicle.id)
+    result = await session.execute(stmt)
+    vehicles = result.scalars().all()
+
+    candidates: list[_VehicleCandidate] = []
+    preference = booking_request.vehicle_preference
+
+    for vehicle in vehicles:
+        available = await is_vehicle_available(
+            session,
+            vehicle=vehicle,
+            start=booking_request.start_datetime,
+            end=booking_request.end_datetime,
+            exclude_booking_id=exclude_booking_id,
+        )
+        if not available:
+            continue
+
+        matches_preference = _matches_vehicle_preference(vehicle.vehicle_type, preference)
+        spare_seats = max(vehicle.seating_capacity - booking_request.passenger_count, 0)
+
+        reasons: list[str] = []
+        if preference != VehiclePreference.ANY:
+            if matches_preference:
+                reasons.append("Matches preferred vehicle type")
+            else:
+                reasons.append("Vehicle type differs from preference")
+
+        reasons.append(f"{spare_seats} spare seats")
+
+        score = (0 if matches_preference else 1) * 1_000_000
+        score += spare_seats * 1_000
+        score += vehicle.id
+
+        suggestion = AssignmentVehicleSuggestionData(
+            id=vehicle.id,
+            registration_number=vehicle.registration_number,
+            vehicle_type=vehicle.vehicle_type,
+            seating_capacity=vehicle.seating_capacity,
+            matches_preference=matches_preference,
+            spare_seats=spare_seats,
+        )
+
+        candidates.append(
+            _VehicleCandidate(
+                vehicle=vehicle,
+                suggestion=suggestion,
+                score=score,
+                reasons=reasons,
+            )
+        )
+
+    candidates.sort(key=lambda item: (item.score, item.suggestion.id))
+    return candidates[:limit]
+
+
+async def _collect_driver_candidates(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    limit: int,
+    exclude_driver_ids: Iterable[int] = (),
+    exclude_booking_id: Optional[int] = None,
+) -> list[_DriverCandidate]:
+    stmt: Select[tuple[Driver]] = select(Driver).where(
+        Driver.status == DriverStatus.ACTIVE
+    )
+
+    excluded = frozenset(exclude_driver_ids)
+    if excluded:
+        stmt = stmt.where(Driver.id.notin_(tuple(excluded)))
+
+    stmt = stmt.order_by(Driver.id)
+    result = await session.execute(stmt)
+    drivers = result.scalars().all()
+
+    candidates: list[_DriverCandidate] = []
+
+    for driver in drivers:
+        try:
+            await ensure_driver_available(
+                session,
+                driver=driver,
+                start=booking_request.start_datetime,
+                end=booking_request.end_datetime,
+                exclude_booking_id=exclude_booking_id,
+            )
+        except ValueError:
+            continue
+
+        reasons = ["Driver available for requested window"]
+        if driver.availability_schedule:
+            reasons.append("Within configured availability schedule")
+
+        score = driver.id
+
+        suggestion = AssignmentDriverSuggestionData(
+            id=driver.id,
+            full_name=driver.full_name,
+            license_number=driver.license_number,
+        )
+
+        candidates.append(
+            _DriverCandidate(
+                driver=driver,
+                suggestion=suggestion,
+                score=score,
+                reasons=reasons,
+            )
+        )
+
+    candidates.sort(key=lambda item: (item.score, item.suggestion.id))
+    return candidates[:limit]
+
+
+async def suggest_assignment_options(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    limit: int = 5,
+    exclude_vehicle_ids: Iterable[int] = (),
+    exclude_driver_ids: Iterable[int] = (),
+) -> list[AssignmentSuggestionData]:
+    """Return ranked combinations of available vehicles and drivers."""
+
+    if limit <= 0:
+        return []
+
+    vehicle_candidates = await _collect_vehicle_candidates(
+        session,
+        booking_request=booking_request,
+        limit=max(limit * 2, limit),
+        exclude_vehicle_ids=exclude_vehicle_ids,
+        exclude_booking_id=booking_request.id,
+    )
+
+    driver_candidates = await _collect_driver_candidates(
+        session,
+        booking_request=booking_request,
+        limit=max(limit * 2, limit),
+        exclude_driver_ids=exclude_driver_ids,
+        exclude_booking_id=booking_request.id,
+    )
+
+    suggestions: list[AssignmentSuggestionData] = []
+
+    for vehicle in vehicle_candidates:
+        for driver in driver_candidates:
+            combined_score = vehicle.score * 1_000_000 + driver.score
+            reasons = [*vehicle.reasons, *driver.reasons]
+            suggestions.append(
+                AssignmentSuggestionData(
+                    vehicle=vehicle.suggestion,
+                    driver=driver.suggestion,
+                    score=combined_score,
+                    reasons=reasons,
+                )
+            )
+            if len(suggestions) >= limit:
+                break
+        if len(suggestions) >= limit:
+            break
+
+    return suggestions
+
+
+async def _load_booking_request(
+    session: AsyncSession, booking_request_id: int
+) -> Optional[BookingRequest]:
+    result = await session.execute(
+        select(BookingRequest).where(BookingRequest.id == booking_request_id)
+    )
+    return result.scalar_one_or_none()
+
+
+def _ensure_vehicle_suitable(
+    vehicle: Vehicle, booking_request: BookingRequest
+) -> None:
+    if vehicle.status != VehicleStatus.ACTIVE:
+        raise ValueError("Vehicle is not available for assignment")
+
+    if vehicle.seating_capacity < booking_request.passenger_count:
+        raise ValueError("Vehicle does not meet the passenger capacity requirement")
+
+
+async def _ensure_vehicle_available(
+    session: AsyncSession,
+    *,
+    vehicle: Vehicle,
+    booking_request: BookingRequest,
+    exclude_booking_id: Optional[int],
+) -> None:
+    _ensure_vehicle_suitable(vehicle, booking_request)
+
+    available = await is_vehicle_available(
+        session,
+        vehicle=vehicle,
+        start=booking_request.start_datetime,
+        end=booking_request.end_datetime,
+        exclude_booking_id=exclude_booking_id,
+    )
+
+    if not available:
+        raise ValueError("Vehicle is not available for the requested time window")
+
+
+async def _resolve_resources(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    requested_vehicle_id: Optional[int],
+    requested_driver_id: Optional[int],
+    auto_assign: bool,
+    exclude_vehicle_ids: Sequence[int] = (),
+    exclude_driver_ids: Sequence[int] = (),
+) -> tuple[Vehicle, Driver]:
+    vehicle: Optional[Vehicle] = None
+    driver: Optional[Driver] = None
+
+    if requested_vehicle_id is not None:
+        vehicle = await get_vehicle_by_id(session, requested_vehicle_id)
+        if vehicle is None:
+            raise ValueError("Selected vehicle not found")
+
+    if requested_driver_id is not None:
+        driver = await get_driver_by_id(session, requested_driver_id)
+        if driver is None:
+            raise ValueError("Selected driver not found")
+
+    if auto_assign:
+        if vehicle is None:
+            vehicle_candidates = await _collect_vehicle_candidates(
+                session,
+                booking_request=booking_request,
+                limit=1,
+                exclude_vehicle_ids=exclude_vehicle_ids,
+                exclude_booking_id=booking_request.id,
+            )
+            if not vehicle_candidates:
+                raise ValueError("No available vehicles match the requested window")
+            vehicle = vehicle_candidates[0].vehicle
+
+        if driver is None:
+            driver_candidates = await _collect_driver_candidates(
+                session,
+                booking_request=booking_request,
+                limit=1,
+                exclude_driver_ids=exclude_driver_ids,
+                exclude_booking_id=booking_request.id,
+            )
+            if not driver_candidates:
+                raise ValueError("No available drivers match the requested window")
+            driver = driver_candidates[0].driver
+    else:
+        if vehicle is None or driver is None:
+            raise ValueError(
+                "Manual assignment requires both a vehicle and driver to be provided"
+            )
+
+    assert vehicle is not None  # for the type-checker
+    assert driver is not None
+
+    await _ensure_vehicle_available(
+        session,
+        vehicle=vehicle,
+        booking_request=booking_request,
+        exclude_booking_id=booking_request.id,
+    )
+
+    await ensure_driver_available(
+        session,
+        driver=driver,
+        start=booking_request.start_datetime,
+        end=booking_request.end_datetime,
+        exclude_booking_id=booking_request.id,
+    )
+
+    return vehicle, driver
+
+
+async def create_assignment(
+    session: AsyncSession,
+    assignment_in: AssignmentCreate,
+    *,
+    assigned_by: User,
+) -> Assignment:
+    """Create a new assignment for the supplied booking request."""
+
+    booking = await _load_booking_request(session, assignment_in.booking_request_id)
+    if booking is None:
+        raise ValueError("Booking request not found")
+
+    if booking.status != BookingStatus.APPROVED:
+        raise ValueError("Booking must be approved before resources can be assigned")
+
+    existing = await get_assignment_by_booking_id(session, booking.id)
+    if existing is not None:
+        raise ValueError("Booking already has an assignment")
+
+    vehicle, driver = await _resolve_resources(
+        session,
+        booking_request=booking,
+        requested_vehicle_id=assignment_in.vehicle_id,
+        requested_driver_id=assignment_in.driver_id,
+        auto_assign=assignment_in.auto_assign,
+    )
+
+    booking.status = BookingStatus.ASSIGNED
+
+    assignment = Assignment(
+        booking_request_id=booking.id,
+        vehicle_id=vehicle.id,
+        driver_id=driver.id,
+        assigned_by=assigned_by.id,
+        notes=assignment_in.notes,
+    )
+
+    session.add(assignment)
+    await session.commit()
+    await session.refresh(assignment)
+    await session.refresh(booking)
+    return assignment
+
+
+async def update_assignment(
+    session: AsyncSession,
+    *,
+    assignment: Assignment,
+    assignment_update: AssignmentUpdate,
+    assigned_by: User,
+) -> Assignment:
+    """Reassign resources for an existing booking assignment."""
+
+    booking = await _load_booking_request(session, assignment.booking_request_id)
+    if booking is None:
+        raise ValueError("Booking request not found")
+
+    if booking.status not in {BookingStatus.APPROVED, BookingStatus.ASSIGNED}:
+        raise ValueError("Booking must be approved before resources can be assigned")
+
+    vehicle_id: Optional[int]
+    if "vehicle_id" in assignment_update.model_fields_set:
+        vehicle_id = assignment_update.vehicle_id
+    else:
+        vehicle_id = assignment.vehicle_id
+
+    driver_id: Optional[int]
+    if "driver_id" in assignment_update.model_fields_set:
+        driver_id = assignment_update.driver_id
+    else:
+        driver_id = assignment.driver_id
+
+    if not assignment_update.auto_assign and (
+        vehicle_id is None or driver_id is None
+    ):
+        raise ValueError(
+            "Manual assignment requires both vehicle_id and driver_id to be provided"
+        )
+
+    vehicle, driver = await _resolve_resources(
+        session,
+        booking_request=booking,
+        requested_vehicle_id=vehicle_id,
+        requested_driver_id=driver_id,
+        auto_assign=assignment_update.auto_assign,
+        exclude_vehicle_ids=(assignment.vehicle_id,),
+        exclude_driver_ids=(assignment.driver_id,),
+    )
+
+    assignment.vehicle_id = vehicle.id
+    assignment.driver_id = driver.id
+    assignment.assigned_by = assigned_by.id
+    assignment.assigned_at = datetime.now(timezone.utc)
+
+    if "notes" in assignment_update.model_fields_set:
+        assignment.notes = assignment_update.notes
+
+    booking.status = BookingStatus.ASSIGNED
+
+    await session.commit()
+    await session.refresh(assignment)
+    await session.refresh(booking)
+    return assignment
+
+
+__all__ = [
+    "create_assignment",
+    "get_assignment_by_booking_id",
+    "get_assignment_by_id",
+    "suggest_assignment_options",
+    "update_assignment",
+]

--- a/backend/tests/test_assignment_services.py
+++ b/backend/tests/test_assignment_services.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.booking import BookingStatus, VehiclePreference
+from app.models.driver import DriverStatus
+from app.models.user import User, UserRole
+from app.models.vehicle import FuelType, VehicleStatus, VehicleType
+from app.schemas import (
+    AssignmentCreate,
+    AssignmentUpdate,
+    BookingRequestCreate,
+    DriverCreate,
+    UserCreate,
+    VehicleCreate,
+)
+from app.services import (
+    create_assignment,
+    create_booking_request,
+    create_driver,
+    create_user,
+    create_vehicle,
+    get_booking_request_by_id,
+    suggest_assignment_options,
+    transition_booking_status,
+    update_assignment,
+)
+
+
+def _future_window(hours_from_now: int = 1, duration_hours: int = 2) -> tuple[datetime, datetime]:
+    start = datetime.now(timezone.utc) + timedelta(hours=hours_from_now)
+    end = start + timedelta(hours=duration_hours)
+    return start, end
+
+
+async def _create_manager(session: AsyncSession) -> User:
+    return await create_user(
+        session,
+        UserCreate(
+            username="fleet_manager",
+            email="fleet_manager@example.com",
+            full_name="Fleet Manager",
+            department="Operations",
+            role=UserRole.FLEET_ADMIN,
+            password="Password123",
+        ),
+    )
+
+
+async def _create_driver(
+    session: AsyncSession,
+    *,
+    employee_code: str,
+    full_name: str,
+    status: DriverStatus = DriverStatus.ACTIVE,
+) -> int:
+    driver = await create_driver(
+        session,
+        DriverCreate(
+            employee_code=employee_code,
+            full_name=full_name,
+            phone_number="+62111111111",
+            license_number=f"LIC-{employee_code}",
+            license_type="B",
+            license_expiry_date=date.today() + timedelta(days=365),
+            status=status,
+        ),
+    )
+    return driver.id
+
+
+async def _create_vehicle(
+    session: AsyncSession,
+    *,
+    registration: str,
+    vehicle_type: VehicleType,
+    seating_capacity: int,
+    status: VehicleStatus = VehicleStatus.ACTIVE,
+) -> int:
+    vehicle = await create_vehicle(
+        session,
+        VehicleCreate(
+            registration_number=registration,
+            vehicle_type=vehicle_type,
+            brand="Brand",
+            model="Model",
+            seating_capacity=seating_capacity,
+            fuel_type=FuelType.GASOLINE,
+            status=status,
+        ),
+    )
+    return vehicle.id
+
+
+async def _create_approved_booking(
+    session: AsyncSession,
+    *,
+    requester_id: int,
+    preference: VehiclePreference = VehiclePreference.ANY,
+    passengers: int = 4,
+) -> int:
+    start, end = _future_window()
+    booking = await create_booking_request(
+        session,
+        BookingRequestCreate(
+            requester_id=requester_id,
+            purpose="Client visit",
+            passenger_count=passengers,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="Head Office",
+            dropoff_location="Client Site",
+            vehicle_preference=preference,
+            status=BookingStatus.REQUESTED,
+        ),
+    )
+
+    booking = await transition_booking_status(
+        session, booking_request=booking, new_status=BookingStatus.APPROVED
+    )
+    return booking.id
+
+
+@pytest.mark.asyncio
+async def test_suggest_assignments_prioritises_preference(
+    async_session: AsyncSession,
+) -> None:
+    manager = await _create_manager(async_session)
+    sedan_vehicle_id = await _create_vehicle(
+        async_session,
+        registration="B 1000 XYZ",
+        vehicle_type=VehicleType.SEDAN,
+        seating_capacity=4,
+    )
+    van_vehicle_id = await _create_vehicle(
+        async_session,
+        registration="B 2000 XYZ",
+        vehicle_type=VehicleType.VAN,
+        seating_capacity=8,
+    )
+    await _create_driver(async_session, employee_code="DRV1", full_name="Driver One")
+    await _create_driver(async_session, employee_code="DRV2", full_name="Driver Two")
+
+    booking_id = await _create_approved_booking(
+        async_session,
+        requester_id=manager.id,
+        preference=VehiclePreference.SEDAN,
+    )
+    booking = await get_booking_request_by_id(async_session, booking_id)
+    assert booking is not None
+
+    suggestions = await suggest_assignment_options(
+        async_session, booking_request=booking, limit=5
+    )
+
+    assert suggestions
+    top = suggestions[0]
+    assert top.vehicle.id == sedan_vehicle_id
+    assert top.vehicle.matches_preference is True
+    assert top.vehicle.vehicle_type == VehicleType.SEDAN
+
+
+@pytest.mark.asyncio
+async def test_create_assignment_auto_assigns_resources(
+    async_session: AsyncSession,
+) -> None:
+    manager = await _create_manager(async_session)
+    vehicle_id = await _create_vehicle(
+        async_session,
+        registration="B 3000 XYZ",
+        vehicle_type=VehicleType.SEDAN,
+        seating_capacity=4,
+    )
+    driver_id = await _create_driver(async_session, employee_code="DRV3", full_name="Driver Three")
+
+    booking_id = await _create_approved_booking(
+        async_session, requester_id=manager.id, preference=VehiclePreference.ANY
+    )
+
+    assignment = await create_assignment(
+        async_session,
+        AssignmentCreate(booking_request_id=booking_id),
+        assigned_by=manager,
+    )
+
+    assert assignment.vehicle_id == vehicle_id
+    assert assignment.driver_id == driver_id
+    assert assignment.assigned_by == manager.id
+
+    booking = await get_booking_request_by_id(async_session, booking_id)
+    assert booking is not None and booking.status == BookingStatus.ASSIGNED
+
+
+@pytest.mark.asyncio
+async def test_assignment_conflict_prevention(async_session: AsyncSession) -> None:
+    manager = await _create_manager(async_session)
+    vehicle_id = await _create_vehicle(
+        async_session,
+        registration="B 4000 XYZ",
+        vehicle_type=VehicleType.VAN,
+        seating_capacity=10,
+    )
+    driver_id = await _create_driver(async_session, employee_code="DRV4", full_name="Driver Four")
+
+    booking_one_id = await _create_approved_booking(
+        async_session,
+        requester_id=manager.id,
+        preference=VehiclePreference.ANY,
+    )
+    booking_two_id = await _create_approved_booking(
+        async_session,
+        requester_id=manager.id,
+        preference=VehiclePreference.ANY,
+    )
+
+    await create_assignment(
+        async_session,
+        AssignmentCreate(booking_request_id=booking_one_id),
+        assigned_by=manager,
+    )
+
+    with pytest.raises(ValueError):
+        await create_assignment(
+            async_session,
+            AssignmentCreate(
+                booking_request_id=booking_two_id,
+                vehicle_id=vehicle_id,
+                driver_id=driver_id,
+                auto_assign=False,
+            ),
+            assigned_by=manager,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_assignment_allows_manual_override(
+    async_session: AsyncSession,
+) -> None:
+    manager = await _create_manager(async_session)
+    vehicle_one_id = await _create_vehicle(
+        async_session,
+        registration="B 5000 XYZ",
+        vehicle_type=VehicleType.SEDAN,
+        seating_capacity=4,
+    )
+    vehicle_two_id = await _create_vehicle(
+        async_session,
+        registration="B 6000 XYZ",
+        vehicle_type=VehicleType.VAN,
+        seating_capacity=8,
+    )
+    driver_one_id = await _create_driver(
+        async_session, employee_code="DRV5", full_name="Driver Five"
+    )
+    driver_two_id = await _create_driver(
+        async_session, employee_code="DRV6", full_name="Driver Six"
+    )
+
+    booking_id = await _create_approved_booking(
+        async_session, requester_id=manager.id, preference=VehiclePreference.ANY
+    )
+
+    assignment = await create_assignment(
+        async_session,
+        AssignmentCreate(booking_request_id=booking_id),
+        assigned_by=manager,
+    )
+
+    assert assignment.vehicle_id == vehicle_one_id
+    assert assignment.driver_id == driver_one_id
+
+    updated = await update_assignment(
+        async_session,
+        assignment=assignment,
+        assignment_update=AssignmentUpdate(
+            vehicle_id=vehicle_two_id,
+            driver_id=driver_two_id,
+            auto_assign=False,
+        ),
+        assigned_by=manager,
+    )
+
+    assert updated.vehicle_id == vehicle_two_id
+    assert updated.driver_id == driver_two_id
+    assert updated.assigned_by == manager.id
+    assert updated.assigned_at >= assignment.assigned_at
+


### PR DESCRIPTION
## Summary
- add assignment schemas and services to suggest and validate resource allocations for bookings
- expose management endpoints for assignment suggestions, creation, and reassignment
- tighten the assignment model wiring and cover the workflow with service-level tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca1c504b6c8328b9e4685bf01f5868