### PR TITLE
feat: optimize assignment allocation and tracking

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from .driver import Driver, DriverStatus
 from .booking import BookingRequest, BookingStatus, VehiclePreference
 from .approval import Approval, ApprovalDecision, ApprovalDelegation
 from .assignment import Assignment
+from .assignment_history import AssignmentChangeReason, AssignmentHistory
 from .job_run import JobRun, JobRunStatus
 
 __all__ = [
@@ -34,6 +35,8 @@ __all__ = [
     "ApprovalDecision",
     "ApprovalDelegation",
     "Assignment",
+    "AssignmentChangeReason",
+    "AssignmentHistory",
     "JobRun",
     "JobRunStatus",
 ]

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -41,6 +41,12 @@ class Assignment(Base):
     vehicle = relationship("Vehicle", back_populates="assignments")
     driver = relationship("Driver", back_populates="assignments")
     assigned_by_user = relationship("User", back_populates="assignments_created")
+    history_entries = relationship(
+        "AssignmentHistory",
+        back_populates="assignment",
+        cascade="all, delete-orphan",
+        order_by="AssignmentHistory.created_at",
+    )
 
     def __repr__(self) -> str:
         return (

--- a/backend/app/models/assignment_history.py
+++ b/backend/app/models/assignment_history.py
@@ -1,0 +1,49 @@
+"""Historical audit entries for assignment changes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import DateTime, Enum as SQLAlchemyEnum, ForeignKey, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class AssignmentChangeReason(str, Enum):
+    """Enumerates the reasons an assignment history entry can exist."""
+
+    CREATED = "CREATED"
+    UPDATED = "UPDATED"
+
+
+class AssignmentHistory(Base, TimestampMixin):
+    """Immutable record describing the evolution of an assignment."""
+
+    __tablename__ = "assignment_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    assignment_id: Mapped[int] = mapped_column(
+        ForeignKey("assignments.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    previous_vehicle_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    previous_driver_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    previous_notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    vehicle_id: Mapped[int] = mapped_column(ForeignKey("vehicles.id"), nullable=False)
+    driver_id: Mapped[int] = mapped_column(ForeignKey("drivers.id"), nullable=False)
+    assigned_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    assigned_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    change_reason: Mapped[AssignmentChangeReason] = mapped_column(
+        SQLAlchemyEnum(AssignmentChangeReason, name="assignment_change_reason"),
+        nullable=False,
+    )
+
+    assignment = relationship("Assignment", back_populates="history_entries")
+
+
+__all__ = ["AssignmentChangeReason", "AssignmentHistory"]

--- a/backend/tests/test_assignment_performance.py
+++ b/backend/tests/test_assignment_performance.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from time import perf_counter
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.booking import BookingStatus, VehiclePreference
+from app.models.driver import DriverStatus
+from app.models.user import UserRole
+from app.models.vehicle import FuelType, VehicleStatus, VehicleType
+from app.schemas import (
+    AssignmentCreate,
+    BookingRequestCreate,
+    DriverCreate,
+    UserCreate,
+    VehicleCreate,
+)
+from app.services import (
+    create_assignment,
+    create_booking_request,
+    create_driver,
+    create_user,
+    create_vehicle,
+    suggest_assignment_options,
+    transition_booking_status,
+)
+
+
+def _window_for_index(index: int) -> tuple[datetime, datetime]:
+    start = datetime.now(timezone.utc) + timedelta(hours=1 + index * 3)
+    end = start + timedelta(hours=2)
+    return start, end
+
+
+async def _bootstrap_manager(session: AsyncSession):
+    return await create_user(
+        session,
+        UserCreate(
+            username=f"perf_manager",
+            email="perf_manager@example.com",
+            full_name="Performance Manager",
+            department="Operations",
+            role=UserRole.FLEET_ADMIN,
+            password="Password123",
+        ),
+    )
+
+
+async def _bootstrap_resources(session: AsyncSession, count: int) -> None:
+    expiry_date = datetime.now(timezone.utc).date() + timedelta(days=365)
+    vehicle_types = tuple(VehicleType)
+    for idx in range(count):
+        await create_vehicle(
+            session,
+            VehicleCreate(
+                registration_number=f"PERF-{idx:04d}",
+                vehicle_type=vehicle_types[idx % len(vehicle_types)],
+                brand="Brand",
+                model="Model",
+                seating_capacity=4 + (idx % 4),
+                fuel_type=FuelType.GASOLINE,
+                status=VehicleStatus.ACTIVE,
+            ),
+        )
+        await create_driver(
+            session,
+            DriverCreate(
+                employee_code=f"PERFDRV{idx:03d}",
+                full_name=f"Performance Driver {idx}",
+                phone_number="+6200000000",
+                license_number=f"PERF-LIC-{idx:03d}",
+                license_type="B",
+                license_expiry_date=expiry_date,
+                status=DriverStatus.ACTIVE,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_suggest_assignment_options_scales(async_session: AsyncSession) -> None:
+    manager = await _bootstrap_manager(async_session)
+    await _bootstrap_resources(async_session, count=40)
+
+    start, end = _window_for_index(0)
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=manager.id,
+            purpose="Site visit",
+            passenger_count=4,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="HQ",
+            dropoff_location="Branch",
+            vehicle_preference=VehiclePreference.ANY,
+            status=BookingStatus.REQUESTED,
+        ),
+    )
+    booking = await transition_booking_status(
+        async_session, booking_request=booking, new_status=BookingStatus.APPROVED
+    )
+
+    started = perf_counter()
+    suggestions = await suggest_assignment_options(
+        async_session, booking_request=booking, limit=10
+    )
+    duration = perf_counter() - started
+
+    assert suggestions
+    assert duration < 1.0
+
+
+@pytest.mark.asyncio
+async def test_bulk_auto_assign_performance(async_session: AsyncSession) -> None:
+    manager = await _bootstrap_manager(async_session)
+    await _bootstrap_resources(async_session, count=50)
+
+    started = perf_counter()
+    for idx in range(15):
+        start, end = _window_for_index(idx)
+        booking = await create_booking_request(
+            async_session,
+            BookingRequestCreate(
+                requester_id=manager.id,
+                purpose=f"Performance booking {idx}",
+                passenger_count=4 + (idx % 3),
+                start_datetime=start,
+                end_datetime=end,
+                pickup_location="HQ",
+                dropoff_location="Client",
+                vehicle_preference=VehiclePreference.ANY,
+                status=BookingStatus.REQUESTED,
+            ),
+        )
+        booking = await transition_booking_status(
+            async_session, booking_request=booking, new_status=BookingStatus.APPROVED
+        )
+        assignment = await create_assignment(
+            async_session,
+            AssignmentCreate(booking_request_id=booking.id),
+            assigned_by=manager,
+        )
+        assert assignment is not None
+
+    duration = perf_counter() - started
+    assert duration < 2.5


### PR DESCRIPTION
## Summary
- implement preference-aware vehicle ranking and driver workload balancing when generating and resolving assignments
- add an assignment history model that captures every assignment creation and reassignment event
- extend the assignment service test suite with preference fallback, workload, history validation, and new performance checks

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68ca2441dcb88328b54b2b9b48b91b71