### PR TITLE
Implement job execution check-in/out workflow

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -10,6 +10,7 @@ from app.api.api_v1.endpoints import (
     bookings,
     drivers,
     health,
+    job_runs,
     users,
     vehicles,
 )
@@ -24,3 +25,4 @@ api_router.include_router(vehicles.router, prefix="/vehicles", tags=["vehicles"]
 api_router.include_router(drivers.router, prefix="/drivers", tags=["drivers"])
 api_router.include_router(bookings.router, prefix="/bookings", tags=["bookings"])
 api_router.include_router(assignments.router, prefix="/assignments", tags=["assignments"])
+api_router.include_router(job_runs.router, prefix="/job-runs", tags=["job-runs"])

--- a/backend/app/api/api_v1/endpoints/job_runs.py
+++ b/backend/app/api/api_v1/endpoints/job_runs.py
@@ -1,0 +1,188 @@
+"""API endpoints for job execution tracking."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.db import get_async_session
+from app.models.assignment import Assignment
+from app.models.booking import BookingRequest, BookingStatus
+from app.models.user import User, UserRole
+from app.schemas import JobRunCheckIn, JobRunCheckOut, JobRunRead
+from app.services import (
+    get_assignment_by_booking_id,
+    get_booking_request_by_id,
+    get_job_run_by_booking_id,
+    record_job_check_in,
+    record_job_check_out,
+)
+
+router = APIRouter()
+
+_MANAGEMENT_ROLES = (UserRole.MANAGER, UserRole.FLEET_ADMIN)
+
+
+async def _load_booking(
+    session: AsyncSession, booking_id: int
+) -> BookingRequest:
+    booking = await get_booking_request_by_id(session, booking_id)
+    if booking is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Booking not found",
+        )
+    return booking
+
+
+async def _get_assignment(
+    session: AsyncSession,
+    booking: BookingRequest,
+    *,
+    required: bool = False,
+) -> Assignment | None:
+    assignment = booking.assignment
+    if assignment is None:
+        assignment = await get_assignment_by_booking_id(session, booking.id)
+    if assignment is None and required:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Booking must have an assignment before execution",
+        )
+    return assignment
+
+
+async def _ensure_can_view_job(
+    session: AsyncSession,
+    *,
+    booking: BookingRequest,
+    user: User,
+) -> None:
+    if user.role in _MANAGEMENT_ROLES or user.role == UserRole.AUDITOR:
+        return
+
+    if booking.requester_id == user.id:
+        return
+
+    assignment = await _get_assignment(session, booking, required=False)
+    if (
+        assignment is not None
+        and assignment.driver is not None
+        and assignment.driver.user_id == user.id
+    ):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Insufficient permissions to access this job run",
+    )
+
+
+async def _ensure_can_operate_job(
+    session: AsyncSession,
+    *,
+    booking: BookingRequest,
+    user: User,
+) -> None:
+    if user.role in _MANAGEMENT_ROLES:
+        return
+
+    if user.role == UserRole.DRIVER:
+        assignment = await _get_assignment(session, booking, required=True)
+        if assignment.driver is None or assignment.driver.user_id != user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You are not assigned to this booking",
+            )
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Insufficient permissions to update this job",
+    )
+
+
+@router.get("/by-booking/{booking_id}", response_model=JobRunRead)
+async def get_job_run(
+    booking_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> JobRunRead:
+    """Return the job run data associated with a booking."""
+
+    booking = await _load_booking(session, booking_id)
+    await _ensure_can_view_job(session, booking=booking, user=current_user)
+
+    job_run = await get_job_run_by_booking_id(session, booking_id)
+    if job_run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job run not found",
+        )
+    return job_run
+
+
+@router.post(
+    "/by-booking/{booking_id}/check-in",
+    response_model=JobRunRead,
+)
+async def check_in_job(
+    booking_id: int,
+    payload: JobRunCheckIn,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> JobRunRead:
+    """Record check-in information for a booking job."""
+
+    booking = await _load_booking(session, booking_id)
+    await _ensure_can_operate_job(session, booking=booking, user=current_user)
+
+    if booking.status not in {BookingStatus.ASSIGNED, BookingStatus.IN_PROGRESS}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Booking is not ready for check-in",
+        )
+
+    try:
+        job_run = await record_job_check_in(
+            session, booking_request=booking, payload=payload
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return job_run
+
+
+@router.post(
+    "/by-booking/{booking_id}/check-out",
+    response_model=JobRunRead,
+)
+async def check_out_job(
+    booking_id: int,
+    payload: JobRunCheckOut,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> JobRunRead:
+    """Record check-out information and expenses for a booking job."""
+
+    booking = await _load_booking(session, booking_id)
+    await _ensure_can_operate_job(session, booking=booking, user=current_user)
+
+    try:
+        job_run = await record_job_check_out(
+            session, booking_request=booking, payload=payload
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return job_run
+
+
+__all__ = ["check_in_job", "check_out_job", "get_job_run"]

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -56,6 +56,7 @@ from .assignment import (
     AssignmentVehicleSuggestion,
     AssignmentVehicleSuggestionData,
 )
+from .job_run import JobRunCheckIn, JobRunCheckOut, JobRunRead
 
 __all__ = [
     "LoginRequest",
@@ -100,4 +101,7 @@ __all__ = [
     "AssignmentUpdate",
     "AssignmentVehicleSuggestion",
     "AssignmentVehicleSuggestionData",
+    "JobRunCheckIn",
+    "JobRunCheckOut",
+    "JobRunRead",
 ]

--- a/backend/app/schemas/job_run.py
+++ b/backend/app/schemas/job_run.py
@@ -1,0 +1,136 @@
+"""Schemas for job execution tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+
+from app.models.job_run import JobRunStatus
+
+
+def _normalise_optional_text(value: Optional[str]) -> Optional[str]:
+    """Return a trimmed version of ``value`` or ``None`` when empty."""
+
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _normalise_string_list(value: Optional[list[str]]) -> Optional[list[str]]:
+    """Return a list of non-empty, trimmed strings or ``None``."""
+
+    if value is None:
+        return None
+
+    normalised: list[str] = []
+    for item in value:
+        if item is None:
+            continue
+        trimmed = item.strip()
+        if trimmed:
+            normalised.append(trimmed)
+
+    return normalised or None
+
+
+class JobRunCheckIn(BaseModel):
+    """Payload for recording a booking job check-in."""
+
+    checkin_datetime: datetime
+    checkin_mileage: int = Field(..., ge=0)
+    checkin_location: Optional[str] = Field(default=None, max_length=500)
+    checkin_images: Optional[list[str]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("checkin_location")
+    @classmethod
+    def _normalise_location(cls, value: Optional[str]) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+    @field_validator("checkin_images")
+    @classmethod
+    def _normalise_images(
+        cls, value: Optional[list[str]]
+    ) -> Optional[list[str]]:
+        return _normalise_string_list(value)
+
+
+class JobRunCheckOut(BaseModel):
+    """Payload for recording a booking job check-out."""
+
+    checkout_datetime: datetime
+    checkout_mileage: int = Field(..., ge=0)
+    checkout_location: Optional[str] = Field(default=None, max_length=500)
+    checkout_images: Optional[list[str]] = None
+    fuel_cost: Decimal = Field(default=Decimal("0.00"), ge=0)
+    toll_cost: Decimal = Field(default=Decimal("0.00"), ge=0)
+    other_expenses: Decimal = Field(default=Decimal("0.00"), ge=0)
+    expense_receipts: Optional[list[str]] = None
+    incident_report: Optional[str] = Field(default=None, max_length=2000)
+    incident_images: Optional[list[str]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("checkout_location", "incident_report")
+    @classmethod
+    def _normalise_text_fields(
+        cls, value: Optional[str]
+    ) -> Optional[str]:
+        return _normalise_optional_text(value)
+
+    @field_validator(
+        "checkout_images", "expense_receipts", "incident_images"
+    )
+    @classmethod
+    def _normalise_lists(
+        cls, value: Optional[list[str]]
+    ) -> Optional[list[str]]:
+        return _normalise_string_list(value)
+
+
+class JobRunRead(BaseModel):
+    """Read model representing a job run record."""
+
+    id: int
+    booking_request_id: int
+    status: JobRunStatus
+    checkin_datetime: Optional[datetime] = None
+    checkin_mileage: Optional[int] = None
+    checkin_location: Optional[str] = None
+    checkin_images: Optional[list[str]] = None
+    checkout_datetime: Optional[datetime] = None
+    checkout_mileage: Optional[int] = None
+    checkout_location: Optional[str] = None
+    checkout_images: Optional[list[str]] = None
+    fuel_cost: Decimal
+    toll_cost: Decimal
+    other_expenses: Decimal
+    expense_receipts: Optional[list[str]] = None
+    incident_report: Optional[str] = None
+    incident_images: Optional[list[str]] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @computed_field(return_type=Optional[int])
+    def total_distance(self) -> Optional[int]:
+        """Expose the total distance travelled for API responses."""
+
+        if self.checkin_mileage is None or self.checkout_mileage is None:
+            return None
+        return self.checkout_mileage - self.checkin_mileage
+
+    @computed_field(return_type=Decimal)
+    def total_expenses(self) -> Decimal:
+        """Expose the aggregated expenses for API responses."""
+
+        return self.fuel_cost + self.toll_cost + self.other_expenses
+
+
+__all__ = ["JobRunCheckIn", "JobRunCheckOut", "JobRunRead"]

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -66,6 +66,11 @@ from .assignment import (
     suggest_assignment_options,
     update_assignment,
 )
+from .job_run import (
+    get_job_run_by_booking_id,
+    record_job_check_in,
+    record_job_check_out,
+)
 
 __all__ = [
     "change_user_password",
@@ -122,4 +127,7 @@ __all__ = [
     "get_assignment_by_id",
     "suggest_assignment_options",
     "update_assignment",
+    "get_job_run_by_booking_id",
+    "record_job_check_in",
+    "record_job_check_out",
 ]

--- a/backend/app/services/assignment.py
+++ b/backend/app/services/assignment.py
@@ -15,6 +15,7 @@ from app.models.booking import BookingRequest, BookingStatus, VehiclePreference
 from app.models.driver import Driver, DriverStatus
 from app.models.user import User
 from app.models.vehicle import Vehicle, VehicleStatus, VehicleType
+from app.models.job_run import JobRun
 from app.schemas.assignment import (
     AssignmentCreate,
     AssignmentDriverSuggestionData,
@@ -521,6 +522,9 @@ async def create_assignment(
 
     booking.status = BookingStatus.ASSIGNED
 
+    if booking.job_run is None:
+        booking.job_run = JobRun(booking_request_id=booking.id)
+
     timestamp = datetime.now(timezone.utc)
 
     assignment = Assignment(
@@ -613,6 +617,9 @@ async def update_assignment(
         assignment.notes = assignment_update.notes
 
     booking.status = BookingStatus.ASSIGNED
+
+    if booking.job_run is None:
+        booking.job_run = JobRun(booking_request_id=booking.id)
 
     history_entry = AssignmentHistory(
         assignment=assignment,

--- a/backend/app/services/job_run.py
+++ b/backend/app/services/job_run.py
@@ -1,0 +1,158 @@
+"""Service layer for managing job run execution data."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.assignment import Assignment
+from app.models.booking import BookingRequest, BookingStatus
+from app.models.job_run import JobRun, JobRunStatus
+from app.schemas.job_run import JobRunCheckIn, JobRunCheckOut
+
+
+async def get_job_run_by_booking_id(
+    session: AsyncSession, booking_request_id: int
+) -> Optional[JobRun]:
+    """Return the job run associated with ``booking_request_id`` if present."""
+
+    stmt = select(JobRun).where(JobRun.booking_request_id == booking_request_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def _load_assignment(
+    session: AsyncSession, booking_request: BookingRequest
+) -> Assignment:
+    assignment = booking_request.assignment
+    if assignment is not None:
+        return assignment
+
+    stmt = select(Assignment).where(
+        Assignment.booking_request_id == booking_request.id
+    )
+    result = await session.execute(stmt)
+    assignment = result.scalar_one_or_none()
+    if assignment is None:
+        msg = "Booking must have an assignment before execution can be tracked"
+        raise ValueError(msg)
+    return assignment
+
+
+def _ensure_job_run_instance(booking_request: BookingRequest) -> JobRun:
+    job_run = booking_request.job_run
+    if job_run is None:
+        job_run = JobRun(booking_request_id=booking_request.id)
+    return job_run
+
+
+def _normalise_datetime(value: datetime) -> datetime:
+    """Return *value* converted to naive UTC for comparisons."""
+
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+async def record_job_check_in(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    payload: JobRunCheckIn,
+) -> JobRun:
+    """Record check-in information for the supplied booking."""
+
+    await _load_assignment(session, booking_request)
+
+    if booking_request.status != BookingStatus.ASSIGNED:
+        msg = "Booking must be in ASSIGNED status before check-in"
+        raise ValueError(msg)
+
+    job_run = _ensure_job_run_instance(booking_request)
+
+    if job_run.status in {JobRunStatus.IN_PROGRESS, JobRunStatus.COMPLETED}:
+        raise ValueError("Job has already been checked in")
+
+    if job_run.checkin_datetime is not None:
+        raise ValueError("Check-in details have already been recorded")
+
+    if payload.checkin_datetime is None:
+        raise ValueError("Check-in timestamp is required")
+
+    job_run.checkin_datetime = payload.checkin_datetime
+    job_run.checkin_mileage = payload.checkin_mileage
+    job_run.checkin_location = payload.checkin_location
+    job_run.checkin_images = payload.checkin_images
+    job_run.status = JobRunStatus.IN_PROGRESS
+
+    booking_request.job_run = job_run
+    booking_request.status = BookingStatus.IN_PROGRESS
+
+    session.add(job_run)
+    await session.commit()
+    await session.refresh(job_run)
+    await session.refresh(booking_request)
+    return job_run
+
+
+async def record_job_check_out(
+    session: AsyncSession,
+    *,
+    booking_request: BookingRequest,
+    payload: JobRunCheckOut,
+) -> JobRun:
+    """Record check-out information for the supplied booking."""
+
+    await _load_assignment(session, booking_request)
+
+    if booking_request.status != BookingStatus.IN_PROGRESS:
+        msg = "Booking must be in IN_PROGRESS status before check-out"
+        raise ValueError(msg)
+
+    job_run = booking_request.job_run
+    if job_run is None or job_run.checkin_datetime is None:
+        raise ValueError("Job must be checked in before check-out")
+
+    if job_run.status != JobRunStatus.IN_PROGRESS:
+        raise ValueError("Job is not currently in progress")
+
+    checkout_time = _normalise_datetime(payload.checkout_datetime)
+    checkin_time = _normalise_datetime(job_run.checkin_datetime)
+
+    if checkout_time < checkin_time:
+        raise ValueError("Check-out time cannot be before check-in time")
+
+    if (
+        job_run.checkin_mileage is not None
+        and payload.checkout_mileage < job_run.checkin_mileage
+    ):
+        raise ValueError("Check-out mileage cannot be less than check-in mileage")
+
+    job_run.checkout_datetime = payload.checkout_datetime
+    job_run.checkout_mileage = payload.checkout_mileage
+    job_run.checkout_location = payload.checkout_location
+    job_run.checkout_images = payload.checkout_images
+    job_run.fuel_cost = payload.fuel_cost
+    job_run.toll_cost = payload.toll_cost
+    job_run.other_expenses = payload.other_expenses
+    job_run.expense_receipts = payload.expense_receipts
+    job_run.incident_report = payload.incident_report
+    job_run.incident_images = payload.incident_images
+    job_run.status = JobRunStatus.COMPLETED
+
+    booking_request.status = BookingStatus.COMPLETED
+
+    await session.commit()
+    await session.refresh(job_run)
+    await session.refresh(booking_request)
+    return job_run
+
+
+__all__ = [
+    "get_job_run_by_booking_id",
+    "record_job_check_in",
+    "record_job_check_out",
+]

--- a/backend/tests/test_job_run_services.py
+++ b/backend/tests/test_job_run_services.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.booking import BookingRequest, BookingStatus
+from app.models.driver import DriverStatus
+from app.models.job_run import JobRunStatus
+from app.models.user import User, UserRole
+from app.models.vehicle import FuelType, VehicleStatus, VehicleType
+from app.schemas import (
+    AssignmentCreate,
+    BookingRequestCreate,
+    DriverCreate,
+    JobRunCheckIn,
+    JobRunCheckOut,
+    UserCreate,
+    VehicleCreate,
+)
+from app.services import (
+    create_assignment,
+    create_booking_request,
+    create_driver,
+    create_user,
+    create_vehicle,
+    get_booking_request_by_id,
+    record_job_check_in,
+    record_job_check_out,
+    transition_booking_status,
+)
+
+
+def _future_window(hours_from_now: int = 1, duration_hours: int = 2) -> tuple[datetime, datetime]:
+    start = datetime.now(timezone.utc) + timedelta(hours=hours_from_now)
+    end = start + timedelta(hours=duration_hours)
+    return start, end
+
+
+async def _create_manager(session: AsyncSession) -> User:
+    return await create_user(
+        session,
+        UserCreate(
+            username="fleet_manager",
+            email="fleet_manager@example.com",
+            full_name="Fleet Manager",
+            department="Operations",
+            role=UserRole.FLEET_ADMIN,
+            password="Password123",
+        ),
+    )
+
+
+async def _create_driver_with_user(
+    session: AsyncSession,
+    *,
+    employee_code: str,
+) -> tuple[User, int]:
+    driver_user = await create_user(
+        session,
+        UserCreate(
+            username=f"driver_{employee_code.lower()}",
+            email=f"driver_{employee_code.lower()}@example.com",
+            full_name=f"Driver {employee_code}",
+            department="Fleet",
+            role=UserRole.DRIVER,
+            password="Password123",
+        ),
+    )
+
+    driver = await create_driver(
+        session,
+        DriverCreate(
+            employee_code=employee_code,
+            full_name=f"Driver {employee_code}",
+            phone_number="+62123456789",
+            license_number=f"LIC-{employee_code}",
+            license_type="B",
+            license_expiry_date=date.today() + timedelta(days=365),
+            status=DriverStatus.ACTIVE,
+            user_id=driver_user.id,
+        ),
+    )
+
+    return driver_user, driver.id
+
+
+async def _create_vehicle(
+    session: AsyncSession,
+    *,
+    registration: str,
+    capacity: int = 4,
+) -> int:
+    vehicle = await create_vehicle(
+        session,
+        VehicleCreate(
+            registration_number=registration,
+            vehicle_type=VehicleType.SEDAN,
+            brand="Brand",
+            model="Model",
+            seating_capacity=capacity,
+            fuel_type=FuelType.GASOLINE,
+            status=VehicleStatus.ACTIVE,
+        ),
+    )
+    return vehicle.id
+
+
+async def _prepare_assigned_booking(session: AsyncSession) -> BookingRequest:
+    manager = await _create_manager(session)
+    _, driver_id = await _create_driver_with_user(session, employee_code="DRV100")
+    vehicle_id = await _create_vehicle(session, registration="B 1234 XYZ")
+
+    start, end = _future_window()
+    booking = await create_booking_request(
+        session,
+        BookingRequestCreate(
+            requester_id=manager.id,
+            purpose="Client visit",
+            passenger_count=3,
+            start_datetime=start,
+            end_datetime=end,
+            pickup_location="Head Office",
+            dropoff_location="Client Site",
+            status=BookingStatus.REQUESTED,
+        ),
+    )
+
+    booking = await transition_booking_status(
+        session, booking_request=booking, new_status=BookingStatus.APPROVED
+    )
+
+    await create_assignment(
+        session,
+        AssignmentCreate(
+            booking_request_id=booking.id,
+            vehicle_id=vehicle_id,
+            driver_id=driver_id,
+            notes="Primary assignment",
+            auto_assign=False,
+        ),
+        assigned_by=manager,
+    )
+
+    refreshed = await get_booking_request_by_id(session, booking.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@pytest.mark.asyncio
+async def test_check_in_updates_status_and_details(
+    async_session: AsyncSession,
+) -> None:
+    booking = await _prepare_assigned_booking(async_session)
+
+    check_in_time = datetime.now(timezone.utc)
+    job_run = await record_job_check_in(
+        async_session,
+        booking_request=booking,
+        payload=JobRunCheckIn(
+            checkin_datetime=check_in_time,
+            checkin_mileage=10500,
+            checkin_location=" Main Depot  ",
+            checkin_images=[
+                " https://cdn.example.com/checkin.jpg ",
+                "",
+            ],
+        ),
+    )
+
+    assert job_run.status == JobRunStatus.IN_PROGRESS
+    assert job_run.checkin_location == "Main Depot"
+    assert job_run.checkin_images == ["https://cdn.example.com/checkin.jpg"]
+    assert booking.status == BookingStatus.IN_PROGRESS
+
+    stored = await get_booking_request_by_id(async_session, booking.id)
+    assert stored is not None
+    assert stored.status == BookingStatus.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_check_out_records_expenses_and_completes(
+    async_session: AsyncSession,
+) -> None:
+    booking = await _prepare_assigned_booking(async_session)
+
+    check_in_time = datetime.now(timezone.utc)
+    await record_job_check_in(
+        async_session,
+        booking_request=booking,
+        payload=JobRunCheckIn(
+            checkin_datetime=check_in_time,
+            checkin_mileage=20500,
+            checkin_location="Depot",
+        ),
+    )
+
+    checkout_time = check_in_time + timedelta(hours=4)
+    job_run = await record_job_check_out(
+        async_session,
+        booking_request=booking,
+        payload=JobRunCheckOut(
+            checkout_datetime=checkout_time,
+            checkout_mileage=20640,
+            checkout_location="Depot",
+            fuel_cost=Decimal("45.50"),
+            toll_cost=Decimal("8.75"),
+            other_expenses=Decimal("12.00"),
+            expense_receipts=["https://cdn.example.com/receipt.jpg"],
+        ),
+    )
+
+    assert job_run.status == JobRunStatus.COMPLETED
+    assert job_run.checkout_mileage == 20640
+    assert job_run.total_distance == 140
+    assert job_run.total_expenses == Decimal("66.25")
+
+    stored = await get_booking_request_by_id(async_session, booking.id)
+    assert stored is not None
+    assert stored.status == BookingStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_check_out_requires_prior_check_in(
+    async_session: AsyncSession,
+) -> None:
+    booking = await _prepare_assigned_booking(async_session)
+
+    checkout_time = datetime.now(timezone.utc) + timedelta(hours=3)
+    with pytest.raises(ValueError):
+        await record_job_check_out(
+            async_session,
+            booking_request=booking,
+            payload=JobRunCheckOut(
+                checkout_datetime=checkout_time,
+                checkout_mileage=12000,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_check_in_not_allowed(
+    async_session: AsyncSession,
+) -> None:
+    booking = await _prepare_assigned_booking(async_session)
+    check_in_time = datetime.now(timezone.utc)
+
+    await record_job_check_in(
+        async_session,
+        booking_request=booking,
+        payload=JobRunCheckIn(
+            checkin_datetime=check_in_time,
+            checkin_mileage=15000,
+        ),
+    )
+
+    with pytest.raises(ValueError):
+        await record_job_check_in(
+            async_session,
+            booking_request=booking,
+            payload=JobRunCheckIn(
+                checkin_datetime=check_in_time + timedelta(minutes=10),
+                checkin_mileage=15010,
+            ),
+        )


### PR DESCRIPTION
## Summary
- add job run schemas and service logic to record check-in and check-out details
- expose job run API endpoints and hook assignment creation to provision job run records
- cover the job execution workflow with service-level tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca27b8f6b083289e914839b7229f8e