### PR TITLE
Add resource calendar API and manual event management

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -8,6 +8,7 @@ from app.api.api_v1.endpoints import (
     assignments,
     auth,
     bookings,
+    calendar,
     drivers,
     health,
     job_runs,
@@ -27,6 +28,9 @@ api_router.include_router(drivers.router, prefix="/drivers", tags=["drivers"])
 api_router.include_router(bookings.router, prefix="/bookings", tags=["bookings"])
 api_router.include_router(
     assignments.router, prefix="/assignments", tags=["assignments"]
+)
+api_router.include_router(
+    calendar.router, prefix="/calendar", tags=["calendar"]
 )
 api_router.include_router(job_runs.router, prefix="/job-runs", tags=["job-runs"])
 api_router.include_router(uploads.router, prefix="/uploads", tags=["uploads"])

--- a/backend/app/api/api_v1/endpoints/calendar.py
+++ b/backend/app/api/api_v1/endpoints/calendar.py
@@ -1,0 +1,147 @@
+"""Calendar endpoints for resource scheduling."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import RoleBasedAccess
+from app.db import get_async_session
+from app.models import CalendarResourceType
+from app.models.user import User, UserRole
+from app.schemas import (
+    CalendarEventCreate,
+    CalendarEventRead,
+    CalendarEventUpdate,
+    CalendarResourceView,
+)
+from app.services import (
+    build_resource_calendar_view,
+    create_calendar_event,
+    delete_calendar_event,
+    get_calendar_event_by_id,
+    update_calendar_event,
+)
+
+router = APIRouter()
+
+_MANAGEMENT_ROLES = (UserRole.MANAGER, UserRole.FLEET_ADMIN)
+_manage_calendar = RoleBasedAccess(_MANAGEMENT_ROLES)
+
+
+@router.get("/{resource_type}", response_model=list[CalendarResourceView])
+async def get_resource_calendar(
+    resource_type: CalendarResourceType,
+    start: datetime = Query(..., description="Start of the calendar window"),
+    end: datetime = Query(..., description="End of the calendar window"),
+    resource_ids: Annotated[list[int] | None, Query(None, description="Filter by resource ids")]
+    = None,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_calendar),
+) -> list[CalendarResourceView]:
+    """Return calendar entries grouped by resource."""
+
+    try:
+        return await build_resource_calendar_view(
+            session,
+            resource_type=resource_type,
+            start=start,
+            end=end,
+            resource_ids=resource_ids,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/events", response_model=CalendarEventRead, status_code=status.HTTP_201_CREATED)
+async def create_calendar_entry(
+    event_in: CalendarEventCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(_manage_calendar),
+) -> CalendarEventRead:
+    """Create a manual calendar event for a resource."""
+
+    try:
+        return await create_calendar_event(
+            session, event_in, created_by_id=current_user.id
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.get("/events/{event_id}", response_model=CalendarEventRead)
+async def get_calendar_event(
+    event_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_calendar),
+) -> CalendarEventRead:
+    """Return the calendar event identified by *event_id*."""
+
+    event = await get_calendar_event_by_id(session, event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Calendar event not found",
+        )
+    return event
+
+
+@router.patch("/events/{event_id}", response_model=CalendarEventRead)
+async def update_calendar_entry(
+    event_id: int,
+    event_update: CalendarEventUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_calendar),
+) -> CalendarEventRead:
+    """Update an existing manual calendar event."""
+
+    event = await get_calendar_event_by_id(session, event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Calendar event not found",
+        )
+
+    try:
+        return await update_calendar_event(session, event, event_update)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.delete("/events/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_calendar_entry(
+    event_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_manage_calendar),
+) -> None:
+    """Delete a manual calendar event."""
+
+    event = await get_calendar_event_by_id(session, event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Calendar event not found",
+        )
+
+    await delete_calendar_event(session, event)
+
+
+__all__ = [
+    "create_calendar_entry",
+    "delete_calendar_entry",
+    "get_calendar_event",
+    "get_resource_calendar",
+    "update_calendar_entry",
+]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,11 @@ from .approval import Approval, ApprovalDecision, ApprovalDelegation
 from .assignment import Assignment
 from .assignment_history import AssignmentChangeReason, AssignmentHistory
 from .job_run import JobRun, JobRunStatus, ExpenseStatus
+from .calendar_event import (
+    ResourceCalendarEvent,
+    CalendarEventType,
+    CalendarResourceType,
+)
 
 __all__ = [
     "Base",
@@ -31,6 +36,9 @@ __all__ = [
     "BookingRequest",
     "BookingStatus",
     "VehiclePreference",
+    "ResourceCalendarEvent",
+    "CalendarResourceType",
+    "CalendarEventType",
     "Approval",
     "ApprovalDecision",
     "ApprovalDelegation",

--- a/backend/app/models/calendar_event.py
+++ b/backend/app/models/calendar_event.py
@@ -1,0 +1,69 @@
+"""Calendar event models for resource scheduling."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import DateTime, Enum as SQLAlchemyEnum, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class CalendarResourceType(str, Enum):
+    """Resource types supported by the calendar."""
+
+    VEHICLE = "vehicle"
+    DRIVER = "driver"
+
+
+class CalendarEventType(str, Enum):
+    """Classification of calendar events."""
+
+    BOOKING = "booking"
+    CUSTOM = "custom"
+    MAINTENANCE = "maintenance"
+    BLOCKED = "blocked"
+
+
+class ResourceCalendarEvent(Base, TimestampMixin):
+    """Manual calendar events attached to vehicles or drivers."""
+
+    __tablename__ = "resource_calendar_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    resource_type: Mapped[CalendarResourceType] = mapped_column(
+        SQLAlchemyEnum(CalendarResourceType, name="calendarresourcetype"),
+        nullable=False,
+        index=True,
+    )
+    resource_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    start_datetime: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    end_datetime: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    event_type: Mapped[CalendarEventType] = mapped_column(
+        SQLAlchemyEnum(CalendarEventType, name="calendareventtype"),
+        nullable=False,
+        default=CalendarEventType.CUSTOM,
+    )
+    created_by_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id"), nullable=True, index=True
+    )
+    booking_request_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("booking_requests.id"), nullable=True, index=True
+    )
+
+    created_by = relationship("User")
+
+    def __repr__(self) -> str:
+        return (
+            f"<ResourceCalendarEvent(id={self.id}, resource_type={self.resource_type}, "
+            f"resource_id={self.resource_id}, title='{self.title}')>"
+        )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -31,6 +31,15 @@ from .booking import (
     BookingRequestUpdate,
     BookingStatusUpdate,
 )
+from .calendar import (
+    CalendarConflictView,
+    CalendarEventCreate,
+    CalendarEventRead,
+    CalendarEventSource,
+    CalendarEventUpdate,
+    CalendarEventView,
+    CalendarResourceView,
+)
 from .driver import (
     DriverAvailabilitySchedule,
     DriverAvailabilityUpdate,
@@ -100,6 +109,13 @@ __all__ = [
     "BookingRequestRead",
     "BookingRequestUpdate",
     "BookingStatusUpdate",
+    "CalendarConflictView",
+    "CalendarEventCreate",
+    "CalendarEventRead",
+    "CalendarEventSource",
+    "CalendarEventUpdate",
+    "CalendarEventView",
+    "CalendarResourceView",
     "ApprovalActionRequest",
     "ApprovalNotificationRead",
     "ApprovalRead",

--- a/backend/app/schemas/calendar.py
+++ b/backend/app/schemas/calendar.py
@@ -1,0 +1,114 @@
+"""Pydantic schemas for calendar operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.booking import BookingStatus
+from app.models.calendar_event import CalendarEventType, CalendarResourceType
+
+
+class CalendarEventSource(str, Enum):
+    """Origin of a calendar event entry."""
+
+    ASSIGNMENT = "assignment"
+    MANUAL = "manual"
+
+
+class CalendarEventBase(BaseModel):
+    """Shared fields for manual calendar events."""
+
+    resource_type: CalendarResourceType
+    resource_id: int = Field(..., ge=1)
+    title: str = Field(..., max_length=200)
+    description: Optional[str] = None
+    start: datetime
+    end: datetime
+    event_type: CalendarEventType = CalendarEventType.CUSTOM
+    booking_request_id: Optional[int] = Field(None, ge=1)
+
+    @model_validator(mode="after")
+    def _ensure_valid_range(self) -> "CalendarEventBase":
+        if self.start >= self.end:
+            raise ValueError("Event end time must be after the start time")
+        return self
+
+
+class CalendarEventCreate(CalendarEventBase):
+    """Schema for creating manual calendar events."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CalendarEventUpdate(BaseModel):
+    """Schema for updating manual calendar events."""
+
+    title: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+    start: Optional[datetime] = None
+    end: Optional[datetime] = None
+    event_type: Optional[CalendarEventType] = None
+    booking_request_id: Optional[int] = Field(None, ge=1)
+
+    @model_validator(mode="after")
+    def _ensure_valid_range(self) -> "CalendarEventUpdate":
+        if self.start is not None and self.end is not None and self.start >= self.end:
+            raise ValueError("Event end time must be after the start time")
+        return self
+
+
+class CalendarEventRead(CalendarEventBase):
+    """Schema returned for manual calendar events."""
+
+    id: int
+    created_by_id: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CalendarEventView(BaseModel):
+    """Calendar entry representing either manual events or assignments."""
+
+    reference_id: str
+    resource_type: CalendarResourceType
+    resource_id: int
+    title: str
+    start: datetime
+    end: datetime
+    event_type: CalendarEventType
+    source: CalendarEventSource
+    description: Optional[str] = None
+    booking_request_id: Optional[int] = None
+    booking_status: Optional[BookingStatus] = None
+    assignment_id: Optional[int] = None
+    calendar_event_id: Optional[int] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CalendarConflictView(BaseModel):
+    """Conflict window between overlapping events."""
+
+    start: datetime
+    end: datetime
+    event_reference_ids: list[str]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CalendarResourceView(BaseModel):
+    """Events grouped under a particular resource."""
+
+    resource_type: CalendarResourceType
+    resource_id: int
+    resource_name: str
+    events: list[CalendarEventView]
+    conflicts: list[CalendarConflictView]
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -53,6 +53,14 @@ from .job_run import (
     record_job_check_out,
     review_job_expenses,
 )
+from .calendar import (
+    build_resource_calendar_view,
+    create_calendar_event,
+    delete_calendar_event,
+    get_calendar_event_by_id,
+    list_calendar_events,
+    update_calendar_event,
+)
 from .user import (
     change_user_password,
     create_user,
@@ -142,4 +150,10 @@ __all__ = [
     "record_job_check_out",
     "ReceiptValidationError",
     "review_job_expenses",
+    "build_resource_calendar_view",
+    "create_calendar_event",
+    "delete_calendar_event",
+    "get_calendar_event_by_id",
+    "list_calendar_events",
+    "update_calendar_event",
 ]

--- a/backend/app/services/calendar.py
+++ b/backend/app/services/calendar.py
@@ -1,0 +1,388 @@
+"""Service layer for resource calendar operations."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Iterable, Optional, Sequence
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    Assignment,
+    BookingRequest,
+    BookingStatus,
+    CalendarEventType,
+    CalendarResourceType,
+    Driver,
+    ResourceCalendarEvent,
+    Vehicle,
+)
+from app.schemas import (
+    CalendarConflictView,
+    CalendarEventCreate,
+    CalendarEventSource,
+    CalendarEventUpdate,
+    CalendarEventView,
+    CalendarResourceView,
+)
+
+_RELEVANT_ASSIGNMENT_STATUSES: frozenset[BookingStatus] = frozenset(
+    {
+        BookingStatus.APPROVED,
+        BookingStatus.ASSIGNED,
+        BookingStatus.IN_PROGRESS,
+        BookingStatus.COMPLETED,
+    }
+)
+
+
+def _ensure_window(start: datetime, end: datetime) -> None:
+    if start >= end:
+        msg = "End datetime must be after the start datetime"
+        raise ValueError(msg)
+
+
+def _ensure_timezone(value: datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        msg = f"{field_name} must be timezone-aware"
+        raise ValueError(msg)
+
+
+async def _ensure_resource_exists(
+    session: AsyncSession, resource_type: CalendarResourceType, resource_id: int
+) -> None:
+    if resource_type == CalendarResourceType.VEHICLE:
+        stmt: Select[tuple[int]] = select(Vehicle.id).where(Vehicle.id == resource_id)
+    else:
+        stmt = select(Driver.id).where(Driver.id == resource_id)
+
+    result = await session.execute(stmt)
+    if result.scalar_one_or_none() is None:
+        msg = f"{resource_type.value.capitalize()} with id {resource_id} not found"
+        raise ValueError(msg)
+
+
+async def get_calendar_event_by_id(
+    session: AsyncSession, event_id: int
+) -> Optional[ResourceCalendarEvent]:
+    """Return the manual calendar event identified by *event_id*, if any."""
+
+    result = await session.execute(
+        select(ResourceCalendarEvent).where(ResourceCalendarEvent.id == event_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def create_calendar_event(
+    session: AsyncSession,
+    event_in: CalendarEventCreate,
+    *,
+    created_by_id: Optional[int] = None,
+) -> ResourceCalendarEvent:
+    """Create a new manual calendar event."""
+
+    if event_in.event_type == CalendarEventType.BOOKING:
+        raise ValueError("Manual calendar events cannot use the booking event type")
+
+    _ensure_timezone(event_in.start, "start")
+    _ensure_timezone(event_in.end, "end")
+    await _ensure_resource_exists(session, event_in.resource_type, event_in.resource_id)
+
+    event = ResourceCalendarEvent(
+        resource_type=event_in.resource_type,
+        resource_id=event_in.resource_id,
+        title=event_in.title,
+        description=event_in.description,
+        start_datetime=event_in.start,
+        end_datetime=event_in.end,
+        event_type=event_in.event_type,
+        created_by_id=created_by_id,
+        booking_request_id=event_in.booking_request_id,
+    )
+    session.add(event)
+    await session.commit()
+    await session.refresh(event)
+    return event
+
+
+async def update_calendar_event(
+    session: AsyncSession,
+    event: ResourceCalendarEvent,
+    event_update: CalendarEventUpdate,
+) -> ResourceCalendarEvent:
+    """Update *event* with the supplied data."""
+
+    if event_update.event_type == CalendarEventType.BOOKING:
+        raise ValueError("Manual calendar events cannot use the booking event type")
+
+    update_data = event_update.model_dump(exclude_unset=True)
+
+    start = update_data.get("start", event.start_datetime)
+    end = update_data.get("end", event.end_datetime)
+    _ensure_window(start, end)
+    _ensure_timezone(start, "start")
+    _ensure_timezone(end, "end")
+
+    if "title" in update_data:
+        event.title = update_data["title"]
+    if "description" in update_data:
+        event.description = update_data["description"]
+    if "start" in update_data:
+        event.start_datetime = update_data["start"]
+    if "end" in update_data:
+        event.end_datetime = update_data["end"]
+    if "event_type" in update_data:
+        event.event_type = update_data["event_type"]
+    if "booking_request_id" in update_data:
+        event.booking_request_id = update_data["booking_request_id"]
+
+    await session.commit()
+    await session.refresh(event)
+    return event
+
+
+async def delete_calendar_event(
+    session: AsyncSession, event: ResourceCalendarEvent
+) -> None:
+    """Remove the supplied manual calendar event."""
+
+    await session.delete(event)
+    await session.commit()
+
+
+async def list_calendar_events(
+    session: AsyncSession,
+    *,
+    resource_type: CalendarResourceType,
+    start: datetime,
+    end: datetime,
+    resource_ids: Optional[Sequence[int]] = None,
+) -> list[ResourceCalendarEvent]:
+    """Return manual events overlapping the supplied window."""
+
+    _ensure_window(start, end)
+    _ensure_timezone(start, "start")
+    _ensure_timezone(end, "end")
+
+    stmt = select(ResourceCalendarEvent).where(
+        ResourceCalendarEvent.resource_type == resource_type,
+        ResourceCalendarEvent.start_datetime < end,
+        ResourceCalendarEvent.end_datetime > start,
+    )
+    if resource_ids:
+        stmt = stmt.where(ResourceCalendarEvent.resource_id.in_(tuple(resource_ids)))
+
+    stmt = stmt.order_by(ResourceCalendarEvent.start_datetime)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _load_resource_names(
+    session: AsyncSession,
+    resource_type: CalendarResourceType,
+    resource_ids: Iterable[int],
+) -> dict[int, str]:
+    identifiers = tuple({rid for rid in resource_ids if rid})
+    if not identifiers:
+        return {}
+
+    if resource_type == CalendarResourceType.VEHICLE:
+        stmt = select(Vehicle.id, Vehicle.registration_number).where(
+            Vehicle.id.in_(identifiers)
+        )
+    else:
+        stmt = select(Driver.id, Driver.full_name).where(Driver.id.in_(identifiers))
+
+    result = await session.execute(stmt)
+    return {row[0]: row[1] for row in result.all()}
+
+
+def _manual_event_to_view(event: ResourceCalendarEvent) -> CalendarEventView:
+    return CalendarEventView(
+        reference_id=f"manual:{event.id}",
+        resource_type=event.resource_type,
+        resource_id=event.resource_id,
+        title=event.title,
+        start=event.start_datetime,
+        end=event.end_datetime,
+        event_type=event.event_type,
+        source=CalendarEventSource.MANUAL,
+        description=event.description,
+        booking_request_id=event.booking_request_id,
+        calendar_event_id=event.id,
+    )
+
+
+async def _list_assignment_events(
+    session: AsyncSession,
+    *,
+    resource_type: CalendarResourceType,
+    start: datetime,
+    end: datetime,
+    resource_ids: Optional[Sequence[int]] = None,
+) -> list[CalendarEventView]:
+    stmt = (
+        select(
+            Assignment.id,
+            Assignment.vehicle_id,
+            Assignment.driver_id,
+            BookingRequest.id,
+            BookingRequest.purpose,
+            BookingRequest.start_datetime,
+            BookingRequest.end_datetime,
+            BookingRequest.status,
+        )
+        .join(BookingRequest, Assignment.booking_request_id == BookingRequest.id)
+        .where(BookingRequest.start_datetime < end)
+        .where(BookingRequest.end_datetime > start)
+        .where(BookingRequest.status.in_(_RELEVANT_ASSIGNMENT_STATUSES))
+        .order_by(BookingRequest.start_datetime)
+    )
+
+    if resource_type == CalendarResourceType.VEHICLE:
+        stmt = stmt.where(Assignment.vehicle_id.is_not(None))
+        if resource_ids:
+            stmt = stmt.where(Assignment.vehicle_id.in_(tuple(resource_ids)))
+    else:
+        stmt = stmt.where(Assignment.driver_id.is_not(None))
+        if resource_ids:
+            stmt = stmt.where(Assignment.driver_id.in_(tuple(resource_ids)))
+
+    result = await session.execute(stmt)
+    events: list[CalendarEventView] = []
+    for (
+        assignment_id,
+        vehicle_id,
+        driver_id,
+        booking_id,
+        purpose,
+        start_dt,
+        end_dt,
+        status,
+    ) in result.all():
+        resource_id = (
+            vehicle_id if resource_type == CalendarResourceType.VEHICLE else driver_id
+        )
+        if resource_id is None:
+            continue
+
+        events.append(
+            CalendarEventView(
+                reference_id=f"assignment:{assignment_id}",
+                resource_type=resource_type,
+                resource_id=resource_id,
+                title=purpose,
+                start=start_dt,
+                end=end_dt,
+                event_type=CalendarEventType.BOOKING,
+                source=CalendarEventSource.ASSIGNMENT,
+                booking_request_id=booking_id,
+                booking_status=status,
+                assignment_id=assignment_id,
+            )
+        )
+
+    return events
+
+
+def _build_conflicts(events: Sequence[CalendarEventView]) -> list[CalendarConflictView]:
+    conflicts: dict[tuple[str, str], CalendarConflictView] = {}
+    sorted_events = sorted(events, key=lambda item: item.start)
+
+    for index, event in enumerate(sorted_events):
+        for other in sorted_events[index + 1 :]:
+            if other.start >= event.end:
+                break
+            overlap_start = max(event.start, other.start)
+            overlap_end = min(event.end, other.end)
+            if overlap_start >= overlap_end:
+                continue
+            refs = tuple(sorted((event.reference_id, other.reference_id)))
+            conflicts[refs] = CalendarConflictView(
+                start=overlap_start,
+                end=overlap_end,
+                event_reference_ids=list(refs),
+            )
+
+    return list(conflicts.values())
+
+
+async def build_resource_calendar_view(
+    session: AsyncSession,
+    *,
+    resource_type: CalendarResourceType,
+    start: datetime,
+    end: datetime,
+    resource_ids: Optional[Sequence[int]] = None,
+) -> list[CalendarResourceView]:
+    """Return calendar entries grouped by resource."""
+
+    _ensure_window(start, end)
+    _ensure_timezone(start, "start")
+    _ensure_timezone(end, "end")
+
+    manual_events = await list_calendar_events(
+        session,
+        resource_type=resource_type,
+        start=start,
+        end=end,
+        resource_ids=resource_ids,
+    )
+    assignment_events = await _list_assignment_events(
+        session,
+        resource_type=resource_type,
+        start=start,
+        end=end,
+        resource_ids=resource_ids,
+    )
+
+    resource_pool: set[int] = set(resource_ids or [])
+    resource_pool.update(event.resource_id for event in manual_events)
+    resource_pool.update(event.resource_id for event in assignment_events)
+
+    resource_names = await _load_resource_names(session, resource_type, resource_pool)
+    if resource_ids:
+        missing = [rid for rid in resource_ids if rid not in resource_names]
+        if missing:
+            missing_str = ", ".join(str(item) for item in missing)
+            msg = f"Unknown {resource_type.value} ids: {missing_str}"
+            raise ValueError(msg)
+
+    for rid in resource_pool:
+        resource_names.setdefault(
+            rid, f"{resource_type.value.title()} #{rid}"
+        )
+
+    grouped_events: dict[int, list[CalendarEventView]] = defaultdict(list)
+    for event in manual_events:
+        grouped_events[event.resource_id].append(_manual_event_to_view(event))
+    for event in assignment_events:
+        grouped_events[event.resource_id].append(event)
+
+    views: list[CalendarResourceView] = []
+    for resource_id in sorted(resource_pool, key=lambda rid: resource_names.get(rid, "")):
+        events = sorted(grouped_events.get(resource_id, []), key=lambda item: item.start)
+        conflicts = _build_conflicts(events)
+        views.append(
+            CalendarResourceView(
+                resource_type=resource_type,
+                resource_id=resource_id,
+                resource_name=resource_names.get(resource_id, str(resource_id)),
+                events=events,
+                conflicts=conflicts,
+            )
+        )
+
+    return views
+
+
+__all__ = [
+    "build_resource_calendar_view",
+    "create_calendar_event",
+    "delete_calendar_event",
+    "get_calendar_event_by_id",
+    "list_calendar_events",
+    "update_calendar_event",
+]

--- a/backend/tests/test_calendar_services.py
+++ b/backend/tests/test_calendar_services.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    CalendarEventType,
+    CalendarResourceType,
+    UserRole,
+    VehicleType,
+    BookingStatus,
+)
+from app.schemas import (
+    AssignmentCreate,
+    BookingRequestCreate,
+    CalendarEventCreate,
+    DriverCreate,
+    UserCreate,
+    VehicleCreate,
+)
+from app.services import (
+    build_resource_calendar_view,
+    create_assignment,
+    create_booking_request,
+    create_calendar_event,
+    create_driver,
+    create_user,
+    create_vehicle,
+    get_calendar_event_by_id,
+    transition_booking_status,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_manual_calendar_event(async_session: AsyncSession) -> None:
+    manager = await create_user(
+        async_session,
+        UserCreate(
+            username="calendar_manager",
+            email="calendar_manager@example.com",
+            full_name="Calendar Manager",
+            department="Operations",
+            role=UserRole.FLEET_ADMIN,
+            password="Password123",
+        ),
+    )
+
+    vehicle = await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 9991 XYZ",
+            vehicle_type=VehicleType.SEDAN,
+            brand="Brand",
+            model="Model",
+            seating_capacity=4,
+        ),
+    )
+
+    start = datetime.now(timezone.utc) + timedelta(hours=1)
+    end = start + timedelta(hours=2)
+
+    event = await create_calendar_event(
+        async_session,
+        CalendarEventCreate(
+            resource_type=CalendarResourceType.VEHICLE,
+            resource_id=vehicle.id,
+            title="Scheduled maintenance",
+            start=start,
+            end=end,
+            event_type=CalendarEventType.MAINTENANCE,
+        ),
+        created_by_id=manager.id,
+    )
+
+    stored = await get_calendar_event_by_id(async_session, event.id)
+    assert stored is not None
+    assert stored.created_by_id == manager.id
+    assert stored.resource_id == vehicle.id
+    assert stored.event_type == CalendarEventType.MAINTENANCE
+
+
+@pytest.mark.asyncio
+async def test_calendar_view_highlights_conflicts(async_session: AsyncSession) -> None:
+    manager = await create_user(
+        async_session,
+        UserCreate(
+            username="calendar_admin",
+            email="calendar_admin@example.com",
+            full_name="Calendar Admin",
+            department="Operations",
+            role=UserRole.FLEET_ADMIN,
+            password="Password123",
+        ),
+    )
+
+    driver = await create_driver(
+        async_session,
+        DriverCreate(
+            employee_code="DRV-CAL",
+            full_name="Calendar Driver",
+            phone_number="+621111111",
+            license_number="LIC-CAL",
+            license_type="B",
+            license_expiry_date=datetime.now(timezone.utc).date() + timedelta(days=365),
+        ),
+    )
+
+    vehicle = await create_vehicle(
+        async_session,
+        VehicleCreate(
+            registration_number="B 9000 CAL",
+            vehicle_type=VehicleType.VAN,
+            brand="Brand",
+            model="Model",
+            seating_capacity=8,
+        ),
+    )
+
+    booking_window_start = datetime.now(timezone.utc) + timedelta(hours=4)
+    booking_window_end = booking_window_start + timedelta(hours=3)
+
+    booking = await create_booking_request(
+        async_session,
+        BookingRequestCreate(
+            requester_id=manager.id,
+            purpose="Client visit",
+            passenger_count=4,
+            start_datetime=booking_window_start,
+            end_datetime=booking_window_end,
+            pickup_location="HQ",
+            dropoff_location="Client",
+            status=BookingStatus.REQUESTED,
+        ),
+    )
+
+    booking = await transition_booking_status(
+        async_session,
+        booking_request=booking,
+        new_status=BookingStatus.APPROVED,
+    )
+
+    assignment = await create_assignment(
+        async_session,
+        AssignmentCreate(
+            booking_request_id=booking.id,
+            vehicle_id=vehicle.id,
+            driver_id=driver.id,
+            auto_assign=False,
+        ),
+        assigned_by=manager,
+    )
+
+    manual_start = booking_window_start + timedelta(hours=1)
+    manual_end = manual_start + timedelta(hours=2)
+
+    manual_event = await create_calendar_event(
+        async_session,
+        CalendarEventCreate(
+            resource_type=CalendarResourceType.VEHICLE,
+            resource_id=vehicle.id,
+            title="Tyre replacement",
+            start=manual_start,
+            end=manual_end,
+            event_type=CalendarEventType.MAINTENANCE,
+        ),
+        created_by_id=manager.id,
+    )
+
+    calendar_window_start = booking_window_start - timedelta(hours=1)
+    calendar_window_end = booking_window_end + timedelta(hours=1)
+
+    views = await build_resource_calendar_view(
+        async_session,
+        resource_type=CalendarResourceType.VEHICLE,
+        start=calendar_window_start,
+        end=calendar_window_end,
+    )
+
+    assert len(views) == 1
+    view = views[0]
+    assert view.resource_id == vehicle.id
+    assert len(view.events) == 2
+
+    event_refs = {event.reference_id for event in view.events}
+    assert f"assignment:{assignment.id}" in event_refs
+    assert f"manual:{manual_event.id}" in event_refs
+
+    assert view.conflicts, "Expected overlapping events to be flagged"
+    conflict_refs = {ref for conflict in view.conflicts for ref in conflict.event_reference_ids}
+    assert f"assignment:{assignment.id}" in conflict_refs
+    assert f"manual:{manual_event.id}" in conflict_refs
+
+
+@pytest.mark.asyncio
+async def test_calendar_view_rejects_unknown_resources(async_session: AsyncSession) -> None:
+    start = datetime.now(timezone.utc) + timedelta(hours=1)
+    end = start + timedelta(hours=2)
+
+    with pytest.raises(ValueError):
+        await build_resource_calendar_view(
+            async_session,
+            resource_type=CalendarResourceType.VEHICLE,
+            start=start,
+            end=end,
+            resource_ids=[999],
+        )


### PR DESCRIPTION
## Summary
- add database model and schemas for resource calendar events
- implement calendar service to merge manual events with booking assignments and detect conflicts
- expose calendar API endpoints and tests covering event creation and conflict detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca3242e28c8328a242f24f51b52686