### PR TITLE
Add multi-channel notifications with LINE integration

### DIFF
--- a/backend/alembic/versions/20240501_0003_notifications.py
+++ b/backend/alembic/versions/20240501_0003_notifications.py
@@ -1,0 +1,75 @@
+"""Introduce notification infrastructure"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20240501_0003"
+down_revision = "20240401_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_preferences",
+        sa.Column("user_id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "in_app_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.true(),
+        ),
+        sa.Column(
+            "email_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+        sa.Column(
+            "line_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+        sa.Column("line_access_token", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("message", sa.String(length=2000), nullable=False),
+        sa.Column("category", sa.String(length=50), nullable=False, server_default="general"),
+        sa.Column("data", sa.JSON(), nullable=True),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("delivered_channels", sa.JSON(), nullable=False),
+        sa.Column("delivery_errors", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_notifications_user_id", "notifications", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notifications_user_id", table_name="notifications")
+    op.drop_table("notifications")
+    op.drop_table("notification_preferences")
+

--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -12,6 +12,7 @@ from app.api.api_v1.endpoints import (
     drivers,
     health,
     job_runs,
+    notifications,
     uploads,
     users,
     vehicles,
@@ -33,4 +34,7 @@ api_router.include_router(
     calendar.router, prefix="/calendar", tags=["calendar"]
 )
 api_router.include_router(job_runs.router, prefix="/job-runs", tags=["job-runs"])
+api_router.include_router(
+    notifications.router, prefix="/notifications", tags=["notifications"]
+)
 api_router.include_router(uploads.router, prefix="/uploads", tags=["uploads"])

--- a/backend/app/api/api_v1/endpoints/notifications.py
+++ b/backend/app/api/api_v1/endpoints/notifications.py
@@ -1,0 +1,146 @@
+"""Notification management API endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.db import get_async_session
+from app.models import Notification
+from app.models.user import User
+from app.schemas import (
+    NotificationCreateRequest,
+    NotificationMarkReadResponse,
+    NotificationPreferenceRead,
+    NotificationPreferenceUpdate,
+    NotificationRead,
+)
+from app.services.notification import NotificationService
+
+router = APIRouter()
+
+
+def _serialise_preference(preference) -> NotificationPreferenceRead:
+    return NotificationPreferenceRead(
+        in_app_enabled=preference.in_app_enabled,
+        email_enabled=preference.email_enabled,
+        line_enabled=preference.line_enabled,
+        line_token_registered=bool(preference.line_access_token),
+        updated_at=preference.updated_at,
+    )
+
+
+@router.get("/", response_model=list[NotificationRead])
+async def list_notifications(
+    limit: int = 20,
+    offset: int = 0,
+    unread_only: bool = False,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> list[NotificationRead]:
+    """Return a list of notifications for the current user."""
+
+    service = NotificationService(session)
+    notifications = await service.list_notifications(
+        current_user.id, limit=limit, offset=offset, unread_only=unread_only
+    )
+    return [NotificationRead.model_validate(notification) for notification in notifications]
+
+
+@router.get("/unread-count")
+async def unread_count(
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, int]:
+    """Return the number of unread notifications for the current user."""
+
+    service = NotificationService(session)
+    count = await service.count_unread(current_user.id)
+    return {"unread": count}
+
+
+@router.post("/{notification_id}/read", response_model=NotificationMarkReadResponse)
+async def mark_notification_read(
+    notification_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> NotificationMarkReadResponse:
+    """Mark the specified notification as read."""
+
+    notification = await session.get(Notification, notification_id)
+    if notification is None or notification.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notification not found",
+        )
+
+    service = NotificationService(session)
+    updated = await service.mark_read(notification)
+    return NotificationMarkReadResponse(
+        notification=NotificationRead.model_validate(updated)
+    )
+
+
+@router.post("/read-all")
+async def mark_all_read(
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, int]:
+    """Mark all notifications as read for the current user."""
+
+    service = NotificationService(session)
+    updated = await service.mark_all_read(current_user.id)
+    return {"updated": updated}
+
+
+@router.get("/preferences", response_model=NotificationPreferenceRead)
+async def get_preferences(
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> NotificationPreferenceRead:
+    """Return the user's current notification preferences."""
+
+    service = NotificationService(session)
+    preference = await service.get_preferences(current_user.id)
+    return _serialise_preference(preference)
+
+
+@router.put("/preferences", response_model=NotificationPreferenceRead)
+async def update_preferences(
+    payload: NotificationPreferenceUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> NotificationPreferenceRead:
+    """Update the user's notification preferences."""
+
+    service = NotificationService(session)
+    preference = await service.update_preferences(
+        current_user.id,
+        in_app_enabled=payload.in_app_enabled,
+        email_enabled=payload.email_enabled,
+        line_enabled=payload.line_enabled,
+        line_access_token=payload.line_access_token,
+    )
+    return _serialise_preference(preference)
+
+
+@router.post("/dispatch-test", response_model=NotificationRead)
+async def dispatch_test_notification(
+    payload: NotificationCreateRequest,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user),
+) -> NotificationRead:
+    """Allow users to trigger a notification to verify their settings."""
+
+    service = NotificationService(session)
+    notification = await service.create_notification(
+        current_user,
+        title=payload.title,
+        message=payload.message,
+        category=payload.category,
+        metadata=payload.metadata,
+        channels=payload.channels,
+    )
+    return NotificationRead.model_validate(notification)
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,6 @@
-"""
-Office Vehicle Booking System - FastAPI Application
-"""
+"""Office Vehicle Booking System - FastAPI Application"""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -11,6 +9,10 @@ import uvicorn
 from app.core.config import settings
 from app.core.logging import setup_logging
 from app.api.api_v1.api import api_router
+from app.db import async_session_factory
+from app.models import User
+from app.services.notification import notification_broadcaster
+from app.utils import InvalidTokenError, decode_token
 
 # Setup logging
 setup_logging()
@@ -63,6 +65,43 @@ async def root():
 async def health_check():
     """Health check endpoint"""
     return {"status": "healthy"}
+
+
+@app.websocket("/ws/notifications")
+async def notifications_websocket(websocket: WebSocket) -> None:
+    """WebSocket endpoint that streams real-time notifications to clients."""
+
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    try:
+        payload = decode_token(token, expected_type="access")
+        user_id = int(payload.get("sub"))
+    except (InvalidTokenError, TypeError, ValueError):
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    async with async_session_factory() as session:
+        user = await session.get(User, user_id)
+        if user is None or not user.is_active:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+
+    await notification_broadcaster.connect(user_id, websocket)
+    await notification_broadcaster.broadcast(
+        user_id, {"type": "connection.established"}
+    )
+
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        notification_broadcaster.disconnect(user_id, websocket)
+    except Exception:  # pragma: no cover - safety catch-all
+        notification_broadcaster.disconnect(user_id, websocket)
+        await websocket.close()
 
 
 if __name__ == "__main__":

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from .approval import Approval, ApprovalDecision, ApprovalDelegation
 from .assignment import Assignment
 from .assignment_history import AssignmentChangeReason, AssignmentHistory
 from .job_run import JobRun, JobRunStatus, ExpenseStatus
+from .notification import Notification, NotificationChannel, NotificationPreference
 from .calendar_event import (
     ResourceCalendarEvent,
     CalendarEventType,
@@ -48,4 +49,7 @@ __all__ = [
     "JobRun",
     "JobRunStatus",
     "ExpenseStatus",
+    "Notification",
+    "NotificationChannel",
+    "NotificationPreference",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,82 @@
+"""Notification-related database models."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base, TimestampMixin
+
+
+class NotificationChannel(str, Enum):
+    """Supported delivery channels for notifications."""
+
+    IN_APP = "in_app"
+    EMAIL = "email"
+    LINE = "line"
+
+
+class Notification(Base, TimestampMixin):
+    """Persistent notification message for a user."""
+
+    __tablename__ = "notifications"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    message: Mapped[str] = mapped_column(String(2000), nullable=False)
+    category: Mapped[str] = mapped_column(String(50), nullable=False, default="general")
+    data: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    read_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    delivered_channels: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    delivery_errors: Mapped[dict[str, str]] = mapped_column(JSON, nullable=False, default=dict)
+
+    user = relationship("User", back_populates="notifications")
+
+    def mark_read(self, timestamp: Optional[datetime] = None) -> None:
+        """Mark the notification as read at *timestamp* (defaults to now)."""
+
+        if self.read_at is not None:
+            return
+        self.read_at = timestamp or datetime.now(timezone.utc)
+
+
+class NotificationPreference(Base, TimestampMixin):
+    """User-specific notification delivery preferences."""
+
+    __tablename__ = "notification_preferences"
+
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    in_app_enabled: Mapped[bool] = mapped_column(default=True, nullable=False)
+    email_enabled: Mapped[bool] = mapped_column(default=False, nullable=False)
+    line_enabled: Mapped[bool] = mapped_column(default=False, nullable=False)
+    line_access_token: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+
+    user = relationship("User", back_populates="notification_preferences")
+
+    def allow_channel(self, channel: NotificationChannel) -> bool:
+        """Return whether *channel* is enabled under this preference."""
+
+        if channel is NotificationChannel.IN_APP:
+            return self.in_app_enabled
+        if channel is NotificationChannel.EMAIL:
+            return self.email_enabled
+        if channel is NotificationChannel.LINE:
+            return self.line_enabled and bool(self.line_access_token)
+        return False
+
+
+__all__ = [
+    "Notification",
+    "NotificationChannel",
+    "NotificationPreference",
+]
+

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -46,6 +46,17 @@ class User(Base, TimestampMixin):
         back_populates="expense_reviewer",
         foreign_keys="JobRun.expense_reviewed_by_id",
     )
+    notifications = relationship(
+        "Notification",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    notification_preferences = relationship(
+        "NotificationPreference",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
     def __repr__(self) -> str:
         return f"<User(id={self.id}, username='{self.username}', role='{self.role}')>"

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -65,6 +65,13 @@ from .image import (
     VehicleImageUploadResponse,
 )
 from .job_run import JobRunCheckIn, JobRunCheckOut, JobRunRead
+from .notification import (
+    NotificationCreateRequest,
+    NotificationMarkReadResponse,
+    NotificationPreferenceRead,
+    NotificationPreferenceUpdate,
+    NotificationRead,
+)
 from .user import (
     UserCreate,
     UserPasswordChange,
@@ -144,6 +151,11 @@ __all__ = [
     "JobRunCheckIn",
     "JobRunCheckOut",
     "JobRunRead",
+    "NotificationCreateRequest",
+    "NotificationMarkReadResponse",
+    "NotificationPreferenceRead",
+    "NotificationPreferenceUpdate",
+    "NotificationRead",
     "SignedUrlResponse",
     "VehicleImageUploadResponse",
 ]

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,81 @@
+"""Pydantic schemas for notification APIs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.notification import NotificationChannel
+
+
+class NotificationRead(BaseModel):
+    """Notification payload returned to clients."""
+
+    id: int
+    title: str
+    message: str
+    category: str
+    data: dict = Field(default_factory=dict)
+    created_at: datetime
+    read_at: Optional[datetime] = None
+    delivered_channels: list[str] = Field(default_factory=list)
+    delivery_errors: dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @property
+    def is_read(self) -> bool:
+        return self.read_at is not None
+
+
+class NotificationMarkReadResponse(BaseModel):
+    """Response returned after marking a notification as read."""
+
+    notification: NotificationRead
+
+
+class NotificationPreferenceRead(BaseModel):
+    """Notification preference settings for a user."""
+
+    in_app_enabled: bool
+    email_enabled: bool
+    line_enabled: bool
+    line_token_registered: bool
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class NotificationPreferenceUpdate(BaseModel):
+    """Payload for updating notification preferences."""
+
+    in_app_enabled: Optional[bool] = None
+    email_enabled: Optional[bool] = None
+    line_enabled: Optional[bool] = None
+    line_access_token: Optional[str] = Field(default=None, min_length=0, max_length=255)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class NotificationCreateRequest(BaseModel):
+    """Internal schema for manually triggering notifications (testing/admin)."""
+
+    title: str = Field(..., max_length=200)
+    message: str = Field(..., max_length=2000)
+    category: str = Field(default="general", max_length=50)
+    metadata: Optional[dict] = None
+    channels: Optional[list[NotificationChannel]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+__all__ = [
+    "NotificationCreateRequest",
+    "NotificationPreferenceRead",
+    "NotificationPreferenceUpdate",
+    "NotificationRead",
+    "NotificationMarkReadResponse",
+]
+

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -67,6 +67,7 @@ from .calendar import (
     unsubscribe_from_calendar_updates,
     update_calendar_event,
 )
+from .notification import NotificationService, notification_broadcaster
 from .user import (
     change_user_password,
     create_user,
@@ -168,4 +169,6 @@ __all__ = [
     "subscribe_to_calendar_updates",
     "unsubscribe_from_calendar_updates",
     "update_calendar_event",
+    "NotificationService",
+    "notification_broadcaster",
 ]

--- a/backend/app/services/line_notify.py
+++ b/backend/app/services/line_notify.py
@@ -1,0 +1,73 @@
+"""Integration helpers for LINE Notify."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from app.core.config import settings
+
+LINE_NOTIFY_ENDPOINT = "https://notify-api.line.me/api/notify"
+
+
+class LineNotifyError(RuntimeError):
+    """Raised when the LINE Notify API returns an error."""
+
+
+@dataclass
+class LineNotifyResponse:
+    """Result from attempting to deliver a LINE notification."""
+
+    success: bool
+    status_code: int
+    message: str
+
+
+class LineNotifyClient:
+    """Thin async client for the LINE Notify REST API."""
+
+    def __init__(self, default_token: Optional[str] = None, timeout: float = 10.0):
+        self._default_token = default_token or settings.LINE_NOTIFY_TOKEN
+        self._timeout = timeout
+
+    async def send_message(
+        self, message: str, *, token: Optional[str] = None
+    ) -> LineNotifyResponse:
+        """Send *message* to LINE using the supplied *token*."""
+
+        access_token = token or self._default_token
+        if not access_token:
+            raise LineNotifyError("LINE Notify access token is not configured")
+
+        headers = {"Authorization": f"Bearer {access_token}"}
+        data = {"message": message}
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(LINE_NOTIFY_ENDPOINT, headers=headers, data=data)
+
+        if response.status_code >= 400:
+            try:
+                payload = response.json()
+                error_message = payload.get("message") or response.text
+            except ValueError:  # pragma: no cover - fallback when JSON parsing fails
+                error_message = response.text
+
+            raise LineNotifyError(
+                f"LINE Notify request failed with {response.status_code}: {error_message}"
+            )
+
+        return LineNotifyResponse(
+            success=True,
+            status_code=response.status_code,
+            message="Message delivered",
+        )
+
+
+__all__ = [
+    "LineNotifyClient",
+    "LineNotifyError",
+    "LineNotifyResponse",
+]
+

--- a/backend/app/services/notification.py
+++ b/backend/app/services/notification.py
@@ -1,0 +1,265 @@
+"""Notification service layer."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import WebSocket
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Notification, NotificationChannel, NotificationPreference, User
+
+from .line_notify import LineNotifyClient, LineNotifyError
+
+
+class NotificationBroadcastManager:
+    """Manages websocket connections for real-time notifications."""
+
+    def __init__(self) -> None:
+        self._connections: dict[int, set[WebSocket]] = {}
+
+    async def connect(self, user_id: int, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self._connections.setdefault(user_id, set()).add(websocket)
+
+    def disconnect(self, user_id: int, websocket: WebSocket) -> None:
+        connections = self._connections.get(user_id)
+        if not connections:
+            return
+        connections.discard(websocket)
+        if not connections:
+            self._connections.pop(user_id, None)
+
+    async def broadcast(self, user_id: int, payload: dict) -> None:
+        connections = list(self._connections.get(user_id, set()))
+        for websocket in connections:
+            try:
+                await websocket.send_json(payload)
+            except Exception:  # pragma: no cover - defensive cleanup
+                try:
+                    await websocket.close()
+                finally:
+                    self.disconnect(user_id, websocket)
+
+
+notification_broadcaster = NotificationBroadcastManager()
+
+
+class NotificationService:
+    """High level orchestrator for user notifications."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        line_client: Optional[LineNotifyClient] = None,
+    ) -> None:
+        self._session = session
+        self._line_client = line_client or LineNotifyClient()
+
+    async def get_preferences(self, user_id: int) -> NotificationPreference:
+        preference = await self._session.get(NotificationPreference, user_id)
+        if preference is None:
+            preference = NotificationPreference(user_id=user_id)
+            self._session.add(preference)
+            await self._session.commit()
+            await self._session.refresh(preference)
+        return preference
+
+    async def update_preferences(
+        self,
+        user_id: int,
+        *,
+        in_app_enabled: Optional[bool] = None,
+        email_enabled: Optional[bool] = None,
+        line_enabled: Optional[bool] = None,
+        line_access_token: Optional[str] = None,
+    ) -> NotificationPreference:
+        preference = await self.get_preferences(user_id)
+
+        if in_app_enabled is not None:
+            preference.in_app_enabled = in_app_enabled
+        if email_enabled is not None:
+            preference.email_enabled = email_enabled
+        if line_enabled is not None:
+            preference.line_enabled = line_enabled
+            if not line_enabled:
+                preference.line_access_token = None
+        if line_access_token is not None:
+            trimmed = line_access_token.strip()
+            preference.line_access_token = trimmed or None
+
+        await self._session.commit()
+        await self._session.refresh(preference)
+        return preference
+
+    async def list_notifications(
+        self,
+        user_id: int,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        unread_only: bool = False,
+    ) -> list[Notification]:
+        stmt: Select[tuple[Notification]] = (
+            select(Notification)
+            .where(Notification.user_id == user_id)
+            .order_by(Notification.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        if unread_only:
+            stmt = stmt.where(Notification.read_at.is_(None))
+
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def count_unread(self, user_id: int) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(Notification)
+            .where(Notification.user_id == user_id, Notification.read_at.is_(None))
+        )
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def mark_read(self, notification: Notification) -> Notification:
+        notification.mark_read(datetime.now(timezone.utc))
+        await self._session.commit()
+        await self._session.refresh(notification)
+        await notification_broadcaster.broadcast(
+            notification.user_id,
+            {
+                "type": "notification.read",
+                "payload": {
+                    "id": notification.id,
+                    "read_at": notification.read_at.isoformat()
+                    if notification.read_at
+                    else None,
+                },
+            },
+        )
+        return notification
+
+    async def mark_all_read(self, user_id: int) -> int:
+        stmt = (
+            select(Notification)
+            .where(Notification.user_id == user_id, Notification.read_at.is_(None))
+        )
+        result = await self._session.execute(stmt)
+        notifications = list(result.scalars().all())
+        now = datetime.now(timezone.utc)
+        for item in notifications:
+            item.mark_read(now)
+        await self._session.commit()
+        for item in notifications:
+            await notification_broadcaster.broadcast(
+                user_id,
+                {
+                    "type": "notification.read",
+                    "payload": {
+                        "id": item.id,
+                        "read_at": item.read_at.isoformat() if item.read_at else None,
+                    },
+                },
+            )
+        return len(notifications)
+
+    async def create_notification(
+        self,
+        user: User,
+        *,
+        title: str,
+        message: str,
+        category: str = "general",
+        metadata: Optional[dict] = None,
+        channels: Optional[Iterable[NotificationChannel]] = None,
+    ) -> Notification:
+        preference = await self.get_preferences(user.id)
+        available_channels = set(
+            channel
+            for channel in NotificationChannel
+            if preference.allow_channel(channel)
+        )
+
+        if channels is not None:
+            target_channels = [channel for channel in channels if channel in available_channels]
+        else:
+            target_channels = list(available_channels)
+
+        # Always persist in-app notifications so that a record exists.
+        if NotificationChannel.IN_APP not in target_channels and preference.in_app_enabled:
+            target_channels.append(NotificationChannel.IN_APP)
+
+        notification = Notification(
+            user_id=user.id,
+            title=title,
+            message=message,
+            category=category,
+            data=metadata,
+            delivered_channels=[channel.value for channel in target_channels],
+            delivery_errors={},
+        )
+        self._session.add(notification)
+        await self._session.commit()
+        await self._session.refresh(notification)
+
+        await notification_broadcaster.broadcast(
+            user.id,
+            {
+                "type": "notification.created",
+                "payload": self._serialise_notification(notification),
+            },
+        )
+
+        # Handle asynchronous integrations after the notification has been persisted.
+        await self._deliver_external_channels(notification, preference, target_channels)
+        return notification
+
+    async def _deliver_external_channels(
+        self,
+        notification: Notification,
+        preference: NotificationPreference,
+        channels: Iterable[NotificationChannel],
+    ) -> None:
+        errors: dict[str, str] = {}
+
+        for channel in channels:
+            if channel is NotificationChannel.LINE:
+                try:
+                    await self._line_client.send_message(
+                        notification.message,
+                        token=preference.line_access_token,
+                    )
+                except LineNotifyError as exc:
+                    errors[channel.value] = str(exc)
+
+        if errors:
+            notification.delivery_errors.update(errors)
+            await self._session.commit()
+            await self._session.refresh(notification)
+
+    def _serialise_notification(self, notification: Notification) -> dict:
+        return {
+            "id": notification.id,
+            "title": notification.title,
+            "message": notification.message,
+            "category": notification.category,
+            "data": notification.data or {},
+            "created_at": notification.created_at.isoformat()
+            if notification.created_at
+            else None,
+            "read_at": notification.read_at.isoformat() if notification.read_at else None,
+            "delivered_channels": notification.delivered_channels,
+            "delivery_errors": notification.delivery_errors,
+        }
+
+
+__all__ = [
+    "NotificationService",
+    "notification_broadcaster",
+]
+

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,9 @@ class _AsyncSessionWrapper:
     def add(self, instance: Any) -> None:
         self._session.add(instance)
 
+    async def get(self, entity: Any, ident: Any):
+        return self._session.get(entity, ident)
+
     async def commit(self) -> None:
         self._session.commit()
 

--- a/backend/tests/test_notification_services.py
+++ b/backend/tests/test_notification_services.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models import Notification, User, UserRole
+from app.services.notification import NotificationService
+
+
+class _StubLineClient:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send_message(self, message: str, *, token: str | None = None):
+        self.messages.append(message)
+        class _Response:
+            success = True
+            status_code = 200
+            message = "ok"
+
+        return _Response()
+
+
+@pytest.mark.asyncio()
+async def test_preferences_created_with_defaults(async_session):
+    user = User(
+        username="alice",
+        email="alice@example.com",
+        full_name="Alice Example",
+        department="IT",
+        role=UserRole.REQUESTER,
+        password_hash="hashed",
+    )
+    async_session.add(user)
+    await async_session.commit()
+
+    service = NotificationService(async_session)
+    preferences = await service.get_preferences(user.id)
+
+    assert preferences.in_app_enabled is True
+    assert preferences.email_enabled is False
+    assert preferences.line_enabled is False
+
+
+@pytest.mark.asyncio()
+async def test_create_notification_persists_record(async_session):
+    user = User(
+        username="bob",
+        email="bob@example.com",
+        full_name="Bob Example",
+        department="Ops",
+        role=UserRole.MANAGER,
+        password_hash="hashed",
+    )
+    async_session.add(user)
+    await async_session.commit()
+
+    stub_line = _StubLineClient()
+    service = NotificationService(async_session, line_client=stub_line)
+    await service.update_preferences(
+        user.id,
+        in_app_enabled=True,
+        line_enabled=True,
+        line_access_token="token-123",
+    )
+
+    notification = await service.create_notification(
+        user,
+        title="Test",
+        message="Booking approved",
+        category="booking",
+        metadata={"booking_id": 1},
+        channels=None,
+    )
+
+    assert notification.id is not None
+    assert notification.data == {"booking_id": 1}
+    assert set(notification.delivered_channels) >= {"in_app", "line"}
+    assert notification.delivery_errors == {}
+    assert stub_line.messages == ["Booking approved"]
+
+
+@pytest.mark.asyncio()
+async def test_mark_all_read_updates_state(async_session):
+    user = User(
+        username="carol",
+        email="carol@example.com",
+        full_name="Carol Example",
+        department="Finance",
+        role=UserRole.MANAGER,
+        password_hash="hashed",
+    )
+    async_session.add(user)
+    await async_session.commit()
+
+    service = NotificationService(async_session)
+
+    for index in range(3):
+        await service.create_notification(
+            user,
+            title=f"Notification {index}",
+            message="Please review booking",
+            category="booking",
+            metadata={"booking_id": index},
+            channels=[],
+        )
+
+    result = await service.mark_all_read(user.id)
+    assert result == 3
+
+    notifications = await service.list_notifications(user.id)
+    assert all(isinstance(item, Notification) and item.read_at is not None for item in notifications)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,30 +1,84 @@
+"use client";
+
+import { FormEvent, useState } from 'react';
+
+import { NotificationCenter } from '../components/notifications/NotificationCenter';
+
 export default function HomePage() {
+  const [tokenInput, setTokenInput] = useState('');
+  const [activeToken, setActiveToken] = useState<string | null>(null);
+
+  const handleConnect = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setActiveToken(tokenInput.trim() || null);
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50">
       <div className="container mx-auto px-4 py-16">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            ระบบจองรถสำนักงาน
-          </h1>
-          <p className="text-xl text-gray-600 mb-8">
-            Office Vehicle Booking System
-          </p>
-          <div className="bg-white rounded-lg shadow-lg p-8 max-w-md mx-auto">
-            <h2 className="text-2xl font-semibold text-gray-800 mb-4">
-              ยินดีต้อนรับ
-            </h2>
-            <p className="text-gray-600 mb-6">
-              ระบบจัดการการจองรถสำนักงานที่ครบครันและใช้งานง่าย
-            </p>
-            <div className="space-y-3">
-              <button className="btn-primary w-full py-3">
-                เข้าสู่ระบบ
-              </button>
-              <button className="btn-secondary w-full py-3">
-                ดูคู่มือการใช้งาน
-              </button>
+        <div className="grid gap-8 lg:grid-cols-[2fr_3fr]">
+          <div className="space-y-6">
+            <div className="rounded-2xl bg-white p-8 shadow-lg">
+              <h1 className="text-4xl font-bold text-gray-900">
+                ระบบจองรถสำนักงาน
+              </h1>
+              <p className="mt-3 text-xl text-gray-600">
+                Office Vehicle Booking System
+              </p>
+              <p className="mt-4 text-sm text-gray-500">
+                แพลตฟอร์มบริหารจัดการการขอใช้รถสำหรับองค์กร พร้อมระบบอนุมัติหลายขั้นตอน
+                การติดตามสถานะ และการแจ้งเตือนหลากหลายช่องทาง
+              </p>
+
+              <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                <button className="btn-primary py-3">เข้าสู่ระบบ</button>
+                <button className="btn-secondary py-3">ดูคู่มือการใช้งาน</button>
+              </div>
             </div>
+
+            <form
+              onSubmit={handleConnect}
+              className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
+            >
+              <h2 className="text-xl font-semibold text-gray-900">
+                เชื่อมต่อศูนย์แจ้งเตือนแบบเรียลไทม์
+              </h2>
+              <p className="mt-2 text-sm text-gray-500">
+                วาง JWT Access Token ของคุณเพื่อรับการแจ้งเตือนแบบทันทีผ่าน WebSocket
+              </p>
+              <div className="mt-4 space-y-3">
+                <input
+                  type="text"
+                  value={tokenInput}
+                  onChange={(event) => setTokenInput(event.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                  placeholder="ใส่ Access Token"
+                />
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="submit"
+                    className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
+                  >
+                    เชื่อมต่อศูนย์แจ้งเตือน
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setActiveToken(null)}
+                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+                  >
+                    ยกเลิกการเชื่อมต่อ
+                  </button>
+                  {activeToken ? (
+                    <span className="text-sm text-green-600">เชื่อมต่อเรียบร้อย</span>
+                  ) : (
+                    <span className="text-sm text-gray-400">ยังไม่ได้เชื่อมต่อ</span>
+                  )}
+                </div>
+              </div>
+            </form>
           </div>
+
+          <NotificationCenter authToken={activeToken} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { FormEvent, useState } from 'react';
+
+import { NotificationHistoryList } from './NotificationHistoryList';
+import { NotificationPreferencesForm } from './NotificationPreferencesForm';
+import { useNotificationCenter } from './useNotificationCenter';
+
+interface NotificationCenterProps {
+  authToken: string | null;
+}
+
+export function NotificationCenter({ authToken }: NotificationCenterProps) {
+  const {
+    notifications,
+    preferences,
+    unreadCount,
+    loading,
+    error,
+    refresh,
+    markAsRead,
+    markAllRead,
+    updatePreferences,
+    sendTestNotification,
+  } = useNotificationCenter(authToken);
+
+  const [testTitle, setTestTitle] = useState('ทดสอบระบบแจ้งเตือน');
+  const [testMessage, setTestMessage] = useState('นี่คือข้อความตัวอย่างสำหรับตรวจสอบการตั้งค่า');
+  const [sendingTest, setSendingTest] = useState(false);
+  const [testStatus, setTestStatus] = useState<string | null>(null);
+
+  if (!authToken) {
+    return (
+      <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">เข้าสู่ระบบเพื่อดูการแจ้งเตือน</h3>
+        <p className="mt-2 text-sm text-gray-500">
+          เมื่อมีการอนุมัติหรือปฏิเสธคำขอจองรถ ระบบจะแจ้งเตือนแบบเรียลไทม์ที่นี่
+        </p>
+      </div>
+    );
+  }
+
+  const handleTestSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSendingTest(true);
+    setTestStatus(null);
+    try {
+      await sendTestNotification(testTitle, testMessage);
+      setTestStatus('ส่งข้อความทดสอบเรียบร้อยแล้ว');
+    } catch (err: any) {
+      setTestStatus(err.message ?? 'ไม่สามารถส่งข้อความทดสอบ');
+    } finally {
+      setSendingTest(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">ศูนย์การแจ้งเตือน</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            จัดการการแจ้งเตือนหลายช่องทางและดูสถานะล่าสุดได้ในจุดเดียว
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              void refresh();
+            }}
+            className="rounded-lg border border-primary-200 px-4 py-2 text-sm font-medium text-primary-600 hover:bg-primary-50"
+          >
+            รีเฟรชข้อมูล
+          </button>
+          {loading && <span className="text-sm text-gray-500">กำลังโหลด...</span>}
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {!preferences && !error && (
+        <div className="rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+          กำลังเตรียมข้อมูลการตั้งค่าการแจ้งเตือน...
+        </div>
+      )}
+
+      {preferences && (
+        <NotificationPreferencesForm preferences={preferences} onUpdate={updatePreferences} />
+      )}
+
+      <form onSubmit={handleTestSubmit} className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">ส่งข้อความทดสอบ</h3>
+        <p className="mt-1 text-sm text-gray-500">
+          ใช้แบบฟอร์มนี้เพื่อตรวจสอบว่าการตั้งค่าการแจ้งเตือนและ LINE Notify ทำงานถูกต้อง
+        </p>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-gray-700">หัวข้อ</label>
+            <input
+              type="text"
+              value={testTitle}
+              onChange={(event) => setTestTitle(event.target.value)}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              disabled={sendingTest}
+            />
+          </div>
+          <div className="flex flex-col gap-2 md:col-span-2">
+            <label className="text-sm font-medium text-gray-700">ข้อความ</label>
+            <textarea
+              value={testMessage}
+              onChange={(event) => setTestMessage(event.target.value)}
+              rows={3}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              disabled={sendingTest}
+            />
+          </div>
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button
+            type="submit"
+            className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={sendingTest}
+          >
+            ส่งข้อความทดสอบ
+          </button>
+          {testStatus && <span className="text-sm text-green-600">{testStatus}</span>}
+        </div>
+      </form>
+
+      <NotificationHistoryList
+        notifications={notifications}
+        onMarkAsRead={markAsRead}
+        onMarkAll={markAllRead}
+        unreadCount={unreadCount}
+        loading={loading}
+      />
+    </div>
+  );
+}
+

--- a/frontend/src/components/notifications/NotificationHistoryList.tsx
+++ b/frontend/src/components/notifications/NotificationHistoryList.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useMemo } from 'react';
+
+import { NotificationItem } from './useNotificationCenter';
+
+interface NotificationHistoryListProps {
+  notifications: NotificationItem[];
+  onMarkAsRead: (id: number) => Promise<void>;
+  onMarkAll: () => Promise<void>;
+  unreadCount: number;
+  loading: boolean;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('th-TH', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+export function NotificationHistoryList({
+  notifications,
+  onMarkAsRead,
+  onMarkAll,
+  unreadCount,
+  loading,
+}: NotificationHistoryListProps) {
+  const sortedNotifications = useMemo(
+    () => [...notifications].sort((a, b) => b.id - a.id),
+    [notifications]
+  );
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">ประวัติการแจ้งเตือน</h3>
+          <p className="text-sm text-gray-500">แจ้งเตือนล่าสุดจะแสดงอยู่ด้านบนสุด</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="rounded-full bg-primary-50 px-3 py-1 text-sm text-primary-600">
+            ยังไม่ได้อ่าน {unreadCount} รายการ
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              void onMarkAll().catch((err) => console.error(err));
+            }}
+            disabled={loading || unreadCount === 0}
+            className="rounded-lg border border-primary-200 px-4 py-2 text-sm font-medium text-primary-600 transition hover:bg-primary-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            ทำเครื่องหมายว่าอ่านทั้งหมด
+          </button>
+        </div>
+      </div>
+
+      <ul className="divide-y divide-gray-200">
+        {sortedNotifications.length === 0 && (
+          <li className="px-6 py-8 text-center text-sm text-gray-500">
+            ยังไม่มีการแจ้งเตือนในระบบ ลองส่งข้อความทดสอบเพื่อเริ่มใช้งาน
+          </li>
+        )}
+
+        {sortedNotifications.map((notification) => {
+          const createdLabel = notification.createdAt
+            ? dateFormatter.format(new Date(notification.createdAt))
+            : '-';
+
+          return (
+            <li key={notification.id} className="flex flex-col gap-3 px-6 py-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold uppercase tracking-wide text-primary-500">
+                    {notification.category}
+                  </span>
+                  {notification.deliveredChannels.map((channel) => (
+                    <span
+                      key={channel}
+                      className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
+                    >
+                      {channel.replace('_', ' ')}
+                    </span>
+                  ))}
+                </div>
+                <p className="mt-1 text-base font-semibold text-gray-900">{notification.title}</p>
+                <p className="mt-1 text-sm text-gray-600">{notification.message}</p>
+                <p className="mt-2 text-xs text-gray-400">สร้างเมื่อ {createdLabel}</p>
+
+                {Object.keys(notification.deliveryErrors ?? {}).length > 0 && (
+                  <p className="mt-2 text-xs text-red-500">
+                    ไม่สามารถส่งบางช่องทาง: {Object.values(notification.deliveryErrors).join(', ')}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-row items-center gap-3 md:flex-col md:items-end">
+                {notification.readAt ? (
+                  <span className="rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-600">
+                    อ่านแล้ว
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void onMarkAsRead(notification.id).catch((err) => console.error(err));
+                    }}
+                    className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
+                  >
+                    ทำเครื่องหมายว่าอ่านแล้ว
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+

--- a/frontend/src/components/notifications/NotificationPreferencesForm.tsx
+++ b/frontend/src/components/notifications/NotificationPreferencesForm.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { FormEvent, useState } from 'react';
+
+import {
+  NotificationPreferences,
+  PreferencesUpdatePayload,
+} from './useNotificationCenter';
+
+interface NotificationPreferencesFormProps {
+  preferences: NotificationPreferences;
+  onUpdate: (payload: PreferencesUpdatePayload) => Promise<void>;
+}
+
+export function NotificationPreferencesForm({
+  preferences,
+  onUpdate,
+}: NotificationPreferencesFormProps) {
+  const [lineToken, setLineToken] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleToggle = async (field: keyof PreferencesUpdatePayload, value: boolean) => {
+    setSaving(true);
+    setStatus(null);
+    try {
+      await onUpdate({ [field]: value } as PreferencesUpdatePayload);
+      setStatus('บันทึกการตั้งค่าเรียบร้อยแล้ว');
+    } catch (err: any) {
+      setStatus(err.message ?? 'เกิดข้อผิดพลาดในการบันทึก');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleLineTokenSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaving(true);
+    setStatus(null);
+    try {
+      await onUpdate({ line_access_token: lineToken || null });
+      setLineToken('');
+      setStatus('อัปเดต LINE Notify token สำเร็จ');
+    } catch (err: any) {
+      setStatus(err.message ?? 'ไม่สามารถอัปเดต LINE token');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-gray-900">การตั้งค่าการแจ้งเตือน</h3>
+        {saving && <span className="text-sm text-primary-500">กำลังบันทึก...</span>}
+      </div>
+      <p className="mt-2 text-sm text-gray-500">
+        เปิดหรือปิดช่องทางการแจ้งเตือนที่คุณต้องการใช้งานได้จากที่นี่
+      </p>
+
+      <div className="mt-4 space-y-4">
+        <label className="flex items-start gap-3">
+          <input
+            type="checkbox"
+            className="mt-1 h-4 w-4 rounded border-gray-300"
+            checked={preferences.inAppEnabled}
+            onChange={(event) => handleToggle('in_app_enabled', event.target.checked)}
+          />
+          <div>
+            <span className="font-medium text-gray-900">แจ้งเตือนในระบบ</span>
+            <p className="text-sm text-gray-500">
+              แสดงประกาศในศูนย์แจ้งเตือนของระบบและเครื่องมือแบบเรียลไทม์
+            </p>
+          </div>
+        </label>
+
+        <label className="flex items-start gap-3">
+          <input
+            type="checkbox"
+            className="mt-1 h-4 w-4 rounded border-gray-300"
+            checked={preferences.emailEnabled}
+            onChange={(event) => handleToggle('email_enabled', event.target.checked)}
+          />
+          <div>
+            <span className="font-medium text-gray-900">อีเมล</span>
+            <p className="text-sm text-gray-500">
+              รับสำเนาอีเมลเมื่อมีการอัปเดตสำคัญของคำขอจองรถ
+            </p>
+          </div>
+        </label>
+
+        <div className="rounded-lg border border-gray-100 p-4">
+          <div className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              className="mt-1 h-4 w-4 rounded border-gray-300"
+              checked={preferences.lineEnabled}
+              onChange={(event) => handleToggle('line_enabled', event.target.checked)}
+            />
+            <div className="flex-1">
+              <span className="font-medium text-gray-900">LINE Notify</span>
+              <p className="text-sm text-gray-500">
+                ส่งข้อความแจ้งเตือนไปยังแอป LINE แบบทันทีเมื่อมีการอนุมัติหรือปฏิเสธคำขอ
+              </p>
+
+              <form className="mt-3 flex flex-col gap-3 md:flex-row" onSubmit={handleLineTokenSubmit}>
+                <input
+                  type="text"
+                  placeholder="ใส่ LINE Notify token"
+                  value={lineToken}
+                  onChange={(event) => setLineToken(event.target.value)}
+                  className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                  disabled={saving}
+                />
+                <button
+                  type="submit"
+                  className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={saving}
+                >
+                  บันทึก Token
+                </button>
+              </form>
+
+              <p className="mt-2 text-sm text-gray-500">
+                สถานะ: {preferences.lineTokenRegistered ? 'เชื่อมต่อแล้ว' : 'ยังไม่ได้เชื่อมต่อ'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {status && <p className="mt-4 text-sm text-green-600">{status}</p>}
+    </div>
+  );
+}
+

--- a/frontend/src/components/notifications/useNotificationCenter.ts
+++ b/frontend/src/components/notifications/useNotificationCenter.ts
@@ -1,0 +1,302 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export interface NotificationItem {
+  id: number;
+  title: string;
+  message: string;
+  category: string;
+  data: Record<string, unknown>;
+  createdAt: string;
+  readAt: string | null;
+  deliveredChannels: string[];
+  deliveryErrors: Record<string, string>;
+}
+
+export interface NotificationPreferences {
+  inAppEnabled: boolean;
+  emailEnabled: boolean;
+  lineEnabled: boolean;
+  lineTokenRegistered: boolean;
+  updatedAt: string;
+}
+
+export interface PreferencesUpdatePayload {
+  in_app_enabled?: boolean;
+  email_enabled?: boolean;
+  line_enabled?: boolean;
+  line_access_token?: string | null;
+}
+
+export interface UseNotificationCenterResult {
+  notifications: NotificationItem[];
+  preferences: NotificationPreferences | null;
+  unreadCount: number;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  markAsRead: (id: number) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  updatePreferences: (payload: PreferencesUpdatePayload) => Promise<void>;
+  sendTestNotification: (title: string, message: string) => Promise<void>;
+}
+
+function normaliseNotification(payload: any): NotificationItem {
+  return {
+    id: payload.id,
+    title: payload.title,
+    message: payload.message,
+    category: payload.category,
+    data: payload.data ?? {},
+    createdAt: payload.created_at,
+    readAt: payload.read_at ?? null,
+    deliveredChannels: payload.delivered_channels ?? [],
+    deliveryErrors: payload.delivery_errors ?? {},
+  };
+}
+
+function normalisePreferences(payload: any): NotificationPreferences {
+  return {
+    inAppEnabled: payload.in_app_enabled,
+    emailEnabled: payload.email_enabled,
+    lineEnabled: payload.line_enabled,
+    lineTokenRegistered: payload.line_token_registered,
+    updatedAt: payload.updated_at,
+  };
+}
+
+function buildHeaders(token: string | null) {
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export function useNotificationCenter(authToken: string | null): UseNotificationCenterResult {
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [preferences, setPreferences] = useState<NotificationPreferences | null>(null);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasToken = Boolean(authToken);
+
+  const fetchNotifications = useCallback(async () => {
+    if (!authToken) return;
+    const response = await fetch(`${API_URL}/api/v1/notifications/`, {
+      headers: buildHeaders(authToken),
+    });
+    if (!response.ok) {
+      throw new Error('ไม่สามารถโหลดการแจ้งเตือน');
+    }
+    const data = await response.json();
+    const parsed = Array.isArray(data) ? data.map(normaliseNotification) : [];
+    setNotifications(parsed);
+    setUnreadCount(parsed.filter((item) => !item.readAt).length);
+  }, [authToken]);
+
+  const fetchPreferences = useCallback(async () => {
+    if (!authToken) return;
+    const response = await fetch(`${API_URL}/api/v1/notifications/preferences`, {
+      headers: buildHeaders(authToken),
+    });
+    if (!response.ok) {
+      throw new Error('ไม่สามารถโหลดการตั้งค่าการแจ้งเตือน');
+    }
+    const data = await response.json();
+    setPreferences(normalisePreferences(data));
+  }, [authToken]);
+
+  const fetchUnread = useCallback(async () => {
+    if (!authToken) return;
+    const response = await fetch(`${API_URL}/api/v1/notifications/unread-count`, {
+      headers: buildHeaders(authToken),
+    });
+    if (!response.ok) return;
+    const data = await response.json();
+    if (typeof data?.unread === 'number') {
+      setUnreadCount(data.unread);
+    }
+  }, [authToken]);
+
+  const refresh = useCallback(async () => {
+    if (!authToken) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await Promise.all([fetchNotifications(), fetchPreferences(), fetchUnread()]);
+    } catch (err: any) {
+      setError(err.message ?? 'เกิดข้อผิดพลาด');
+    } finally {
+      setLoading(false);
+    }
+  }, [authToken, fetchNotifications, fetchPreferences, fetchUnread]);
+
+  const markAsRead = useCallback(
+    async (id: number) => {
+      if (!authToken) return;
+      const response = await fetch(`${API_URL}/api/v1/notifications/${id}/read`, {
+        method: 'POST',
+        headers: buildHeaders(authToken),
+      });
+      if (!response.ok) {
+        throw new Error('ไม่สามารถอัปเดตสถานะการอ่าน');
+      }
+      const data = await response.json();
+      const updated = normaliseNotification(data.notification);
+      setNotifications((items) => {
+        let shouldDecrement = false;
+        const nextItems = items.map((item) => {
+          if (item.id !== updated.id) {
+            return item;
+          }
+          if (!item.readAt && updated.readAt) {
+            shouldDecrement = true;
+          }
+          return { ...item, readAt: updated.readAt };
+        });
+        if (shouldDecrement) {
+          setUnreadCount((count) => Math.max(count - 1, 0));
+        }
+        return nextItems;
+      });
+    },
+    [authToken]
+  );
+
+  const markAllRead = useCallback(async () => {
+    if (!authToken) return;
+    const response = await fetch(`${API_URL}/api/v1/notifications/read-all`, {
+      method: 'POST',
+      headers: buildHeaders(authToken),
+    });
+    if (!response.ok) {
+      throw new Error('ไม่สามารถอัปเดตสถานะการอ่านทั้งหมด');
+    }
+    setNotifications((items) => items.map((item) => ({ ...item, readAt: new Date().toISOString() })));
+    setUnreadCount(0);
+  }, [authToken]);
+
+  const updatePreferences = useCallback(
+    async (payload: PreferencesUpdatePayload) => {
+      if (!authToken) return;
+      const response = await fetch(`${API_URL}/api/v1/notifications/preferences`, {
+        method: 'PUT',
+        headers: buildHeaders(authToken),
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        throw new Error('ไม่สามารถอัปเดตการตั้งค่า');
+      }
+      const data = await response.json();
+      setPreferences(normalisePreferences(data));
+    },
+    [authToken]
+  );
+
+  const sendTestNotification = useCallback(
+    async (title: string, message: string) => {
+      if (!authToken) return;
+      const response = await fetch(`${API_URL}/api/v1/notifications/dispatch-test`, {
+        method: 'POST',
+        headers: buildHeaders(authToken),
+        body: JSON.stringify({ title, message, category: 'test' }),
+      });
+      if (!response.ok) {
+        throw new Error('ไม่สามารถส่งข้อความทดสอบ');
+      }
+      const data = await response.json();
+      const created = normaliseNotification(data);
+      setNotifications((items) => [created, ...items.filter((item) => item.id !== created.id)]);
+      setUnreadCount((count) => count + 1);
+    },
+    [authToken]
+  );
+
+  useEffect(() => {
+    if (!hasToken) {
+      setNotifications([]);
+      setPreferences(null);
+      setUnreadCount(0);
+      return;
+    }
+    refresh();
+  }, [hasToken, refresh]);
+
+  const websocketUrl = useMemo(() => {
+    if (!authToken || !API_URL) return null;
+    try {
+      const url = new URL('/ws/notifications', API_URL);
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+      url.searchParams.set('token', authToken);
+      return url.toString();
+    } catch (err) {
+      console.error('Unable to construct notification websocket URL', err);
+      return null;
+    }
+  }, [authToken]);
+
+  useEffect(() => {
+    if (!websocketUrl) return;
+
+    const socket = new WebSocket(websocketUrl);
+
+    socket.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        if (payload.type === 'notification.created') {
+          const created = normaliseNotification(payload.payload);
+          setNotifications((items) => [created, ...items.filter((item) => item.id !== created.id)]);
+          setUnreadCount((count) => count + 1);
+        }
+        if (payload.type === 'notification.read') {
+          setNotifications((items) => {
+            let shouldDecrement = false;
+            const nextItems = items.map((item) => {
+              if (item.id !== payload.payload?.id) {
+                return item;
+              }
+              const readAt = payload.payload?.read_at ?? item.readAt;
+              if (!item.readAt && payload.payload?.read_at) {
+                shouldDecrement = true;
+              }
+              return { ...item, readAt };
+            });
+            if (shouldDecrement) {
+              setUnreadCount((count) => Math.max(count - 1, 0));
+            }
+            return nextItems;
+          });
+        }
+      } catch (err) {
+        console.error('Failed to parse notification payload', err);
+      }
+    };
+
+    socket.onerror = () => {
+      setError('การเชื่อมต่อการแจ้งเตือนแบบเรียลไทม์ขัดข้อง');
+    };
+
+    return () => {
+      socket.close();
+    };
+  }, [websocketUrl]);
+
+  return {
+    notifications,
+    preferences,
+    unreadCount,
+    loading,
+    error,
+    refresh,
+    markAsRead,
+    markAllRead,
+    updatePreferences,
+    sendTestNotification,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add persistent notification and preference models plus Alembic migration for history and read tracking
- implement notification service with LINE Notify delivery, websocket broadcasting, and API endpoints for listing, marking read, updating preferences, and dispatching test messages
- surface in-app notification center with real-time updates, preference management UI, and LINE token controls on the frontend

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68ca3bd47bc8832889d99ceceabb8b56