### PR TITLE
Implement authentication UI pages and admin 2FA flow

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "next/core-web-vitals",
-    "@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],

--- a/frontend/src/app/admin/2fa/page.tsx
+++ b/frontend/src/app/admin/2fa/page.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { AuthLayout } from '@/components/auth/AuthLayout';
+import { CheckCircle2, Copy, RefreshCw, ShieldAlert, Smartphone } from 'lucide-react';
+
+type TwoFactorMethod = 'authenticator' | 'sms';
+
+const verificationSchema = z.object({
+  code: z
+    .string()
+    .min(6, 'กรุณากรอกรหัส 6 หลัก')
+    .max(6, 'กรุณากรอกรหัส 6 หลัก')
+    .regex(/^[0-9]+$/, 'ต้องเป็นตัวเลขเท่านั้น'),
+  backupCode: z
+    .string()
+    .max(10, 'รหัสสำรองต้องไม่เกิน 10 ตัวอักษร')
+    .optional(),
+});
+
+type VerificationFormValues = z.infer<typeof verificationSchema>;
+
+const methodOptions: { value: TwoFactorMethod; label: string; description: string }[] = [
+  {
+    value: 'authenticator',
+    label: 'แอปพลิเคชัน Authenticator',
+    description: 'สแกน QR Code ด้วย Google Authenticator, Microsoft Authenticator หรือแอปที่รองรับ TOTP',
+  },
+  {
+    value: 'sms',
+    label: 'SMS OTP',
+    description: 'รับรหัส OTP ทางข้อความ SMS สำหรับการเข้าสู่ระบบจากอุปกรณ์ใหม่',
+  },
+];
+
+function generateBackupCodes() {
+  return Array.from({ length: 6 }, () => Math.random().toString(36).slice(2, 7).toUpperCase());
+}
+
+function generateSecretKey() {
+  return Math.random().toString(36).slice(2, 10).toUpperCase();
+}
+
+export default function AdminTwoFactorPage() {
+  const [selectedMethod, setSelectedMethod] = useState<TwoFactorMethod>('authenticator');
+  const [secretKey, setSecretKey] = useState(() => generateSecretKey());
+  const [backupCodes, setBackupCodes] = useState(() => generateBackupCodes());
+  const [verificationMessage, setVerificationMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<VerificationFormValues>({
+    resolver: zodResolver(verificationSchema),
+    defaultValues: {
+      code: '',
+      backupCode: '',
+    },
+  });
+
+  const qrCodeSeed = useMemo(() => `otpauth://totp/CAR-BOOKING:admin?secret=${secretKey}&issuer=CAR-BOOKING`, [secretKey]);
+
+  const handleRefreshSecret = () => {
+    setSecretKey(generateSecretKey());
+    setBackupCodes(generateBackupCodes());
+    setVerificationMessage(null);
+    reset({ code: '', backupCode: '' });
+  };
+
+  const handleCopy = async (value: string) => {
+    try {
+      if (typeof navigator === 'undefined' || !navigator.clipboard) {
+        throw new Error('Clipboard API not available');
+      }
+      await navigator.clipboard.writeText(value);
+      setVerificationMessage('คัดลอกรหัสไปยังคลิปบอร์ดเรียบร้อยแล้ว');
+    } catch (error) {
+      setVerificationMessage('ไม่สามารถคัดลอกอัตโนมัติได้ กรุณาคัดลอกด้วยตนเอง');
+    }
+  };
+
+  const onSubmit = (values: VerificationFormValues) => {
+    setVerificationMessage(
+      `เปิดใช้งานการยืนยันตัวตนสองชั้นสำเร็จ รหัส ${values.code} จะหมดอายุใน 30 วินาที กรุณาเก็บรักษารหัสสำรองให้ปลอดภัย`,
+    );
+    reset({ code: '', backupCode: values.backupCode ?? '' });
+  };
+
+  return (
+    <AuthLayout
+      heading="ตั้งค่าการยืนยันตัวตนสองชั้นสำหรับผู้ดูแลระบบ"
+      subheading="เพิ่มความปลอดภัยให้กับบัญชีผู้ดูแลด้วยการบังคับใช้ 2FA ทุกครั้งที่เข้าสู่ระบบจากอุปกรณ์ใหม่"
+      description="ผู้ดูแลระบบทุกคนจำเป็นต้องเปิดใช้งาน 2FA เพื่อสอดคล้องกับนโยบายความปลอดภัยขององค์กรและมาตรฐาน ISO 27001"
+      footer={
+        <>
+          ต้องการกลับไปยังหน้าจัดการบัญชี?{' '}
+          <Link href="/login" className="font-semibold text-primary-600 hover:text-primary-700">
+            กลับสู่หน้าเข้าสู่ระบบ
+          </Link>
+        </>
+      }
+    >
+      <div className="space-y-8">
+        <section className="space-y-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">เลือกวิธีการรับรหัส</h2>
+              <p className="mt-1 text-sm text-gray-600">
+                ระบบรองรับทั้งการใช้งานผ่านแอปพลิเคชัน Authenticator และการรับรหัส OTP ผ่าน SMS สำหรับสถานการณ์ฉุกเฉิน
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleRefreshSecret}
+              className="inline-flex items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50"
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              สร้างรหัสใหม่
+            </button>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            {methodOptions.map((method) => (
+              <button
+                key={method.value}
+                type="button"
+                onClick={() => setSelectedMethod(method.value)}
+                className={`flex h-full flex-col items-start gap-3 rounded-xl border p-5 text-left transition-all ${
+                  selectedMethod === method.value
+                    ? 'border-primary-500 bg-primary-50 shadow-sm'
+                    : 'border-gray-200 bg-white hover:border-primary-300'
+                }`}
+              >
+                <div className="flex items-center gap-3 text-sm font-semibold text-gray-900">
+                  {method.value === 'authenticator' ? (
+                    <ShieldAlert className="h-5 w-5 text-primary-500" aria-hidden="true" />
+                  ) : (
+                    <Smartphone className="h-5 w-5 text-primary-500" aria-hidden="true" />
+                  )}
+                  {method.label}
+                </div>
+                <p className="text-xs text-gray-600">{method.description}</p>
+              </button>
+            ))}
+          </div>
+          <div className="rounded-lg border-l-4 border-primary-400 bg-primary-50/80 p-4 text-sm text-primary-900">
+            {selectedMethod === 'authenticator' ? (
+              <p>
+                เปิดแอป Google Authenticator หรือ Microsoft Authenticator แล้วเพิ่มบัญชีใหม่ด้วยการสแกน QR Code ที่แสดงด้านล่าง
+                หรือกรอกรหัสลับด้วยตนเองเพื่อสร้างรหัส 6 หลัก
+              </p>
+            ) : (
+              <p>
+                เมื่อเลือก SMS OTP ระบบจะส่งรหัส 6 หลักไปยังหมายเลขโทรศัพท์ที่ลงทะเบียนไว้ หากต้องการปรับปรุงข้อมูล กรุณาติดต่อผู้ดูแลระบบหลักขององค์กร
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section className="grid gap-6 rounded-xl border border-gray-200 bg-white p-6 shadow-inner sm:grid-cols-[1.3fr_1fr]">
+          <div className="space-y-4">
+            <h3 className="text-base font-semibold text-gray-900">สแกน QR Code เพื่อตั้งค่า</h3>
+            <p className="text-sm text-gray-600">
+              ใช้แอปที่รองรับ TOTP สแกน QR Code หรือป้อนรหัสลับด้วยตนเอง หากเลือกวิธี SMS จะใช้รหัสเดียวกันเป็นตัวตรวจสอบ
+            </p>
+            <div className="rounded-lg border border-dashed border-primary-300 bg-primary-50/70 p-4 text-center">
+              <div className="mx-auto flex h-44 w-44 items-center justify-center rounded-lg border border-primary-200 bg-white">
+                <span className="text-xs font-semibold text-primary-500">QR CODE
+                  <br />
+                  {selectedMethod === 'authenticator' ? 'สำหรับแอป Authenticator' : 'สำหรับการยืนยันทาง SMS'}
+                </span>
+              </div>
+              <p className="mt-3 break-all text-xs text-gray-500">ข้อมูล: {qrCodeSeed}</p>
+            </div>
+            <div className="flex items-center justify-between rounded-lg bg-gray-50 p-3 text-sm">
+              <div>
+                <p className="font-semibold text-gray-900">รหัสลับ (Secret Key)</p>
+                <p className="font-mono text-xs text-gray-600">{secretKey}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleCopy(secretKey)}
+                className="inline-flex items-center gap-1 rounded-md border border-gray-200 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-100"
+              >
+                <Copy className="h-4 w-4" aria-hidden="true" /> คัดลอก
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-base font-semibold text-gray-900">รหัสสำรอง (ใช้ครั้งเดียว)</h3>
+            <p className="text-sm text-gray-600">
+              เก็บรหัสสำรองไว้ในที่ปลอดภัย เมื่อไม่สามารถเข้าถึงอุปกรณ์หลัก คุณยังสามารถเข้าสู่ระบบได้ด้วยรหัสเหล่านี้
+            </p>
+            <ul className="grid grid-cols-2 gap-3 font-mono text-sm">
+              {backupCodes.map((code) => (
+                <li key={code} className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-center">
+                  {code}
+                </li>
+              ))}
+            </ul>
+            <button
+              type="button"
+              onClick={() => setBackupCodes(generateBackupCodes())}
+              className="inline-flex items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-100"
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              สร้างรหัสสำรองใหม่
+            </button>
+          </div>
+        </section>
+
+        <section>
+          <h3 className="text-base font-semibold text-gray-900">ยืนยันรหัสเพื่อเปิดใช้งาน</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            กรอกรหัส 6 หลักจากแอปหรือ SMS และสามารถบันทึกรหัสสำรองที่ใช้ทดแทนได้ในกรณีฉุกเฉิน
+          </p>
+          <form className="mt-4 space-y-6" onSubmit={handleSubmit(onSubmit)} noValidate>
+            <div className="grid gap-6 sm:grid-cols-2">
+              <div>
+                <label htmlFor="code" className="form-label">
+                  รหัสยืนยัน 6 หลัก
+                </label>
+                <input
+                  id="code"
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  className="form-input"
+                  placeholder="เช่น 123456"
+                  {...register('code')}
+                />
+                {errors.code ? <p className="form-error">{errors.code.message}</p> : null}
+              </div>
+
+              <div>
+                <label htmlFor="backupCode" className="form-label">
+                  รหัสสำรอง (ถ้ามี)
+                </label>
+                <input
+                  id="backupCode"
+                  type="text"
+                  className="form-input"
+                  placeholder="เช่น ABCD1"
+                  {...register('backupCode')}
+                />
+                {errors.backupCode ? <p className="form-error">{errors.backupCode.message}</p> : null}
+              </div>
+            </div>
+
+            <div className="rounded-lg bg-primary-50 p-4 text-sm text-primary-900">
+              <p className="font-semibold">ข้อแนะนำสำหรับผู้ดูแลระบบ</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                <li>ตรวจสอบให้แน่ใจว่าอุปกรณ์สำรองถูกเพิ่มไว้ในระบบจัดการทรัพย์สินขององค์กรแล้ว</li>
+                <li>หากเปลี่ยนอุปกรณ์ ควรปิดการใช้งาน 2FA เดิมและตั้งค่าใหม่ทันที</li>
+                <li>เก็บรหัสสำรองไว้ในตู้เอกสารหรือ Password Manager ที่องค์กรรับรอง</li>
+              </ul>
+            </div>
+
+            <button type="submit" className="btn-primary flex items-center justify-center gap-2 py-3 text-base">
+              <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+              ยืนยันและเปิดใช้งาน 2FA
+            </button>
+
+            {verificationMessage ? (
+              <div className="rounded-lg bg-success-50 p-4 text-sm text-success-700">{verificationMessage}</div>
+            ) : null}
+          </form>
+        </section>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Link from 'next/link';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useState } from 'react';
+import { AuthLayout } from '@/components/auth/AuthLayout';
+
+const loginSchema = z.object({
+  email: z.string().min(1, 'กรุณากรอกอีเมล').email('รูปแบบอีเมลไม่ถูกต้อง'),
+  password: z.string().min(8, 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร'),
+  remember: z.boolean().optional(),
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
+export default function LoginPage() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionMessage, setSubmissionMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+      remember: true,
+    },
+  });
+
+  const onSubmit = async (values: LoginFormValues) => {
+    setIsSubmitting(true);
+    setSubmissionMessage(null);
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    setSubmissionMessage(
+      `สวัสดี ${values.email}! ระบบกำลังตรวจสอบสิทธิ์ของคุณและเชื่อมต่อกับแดชบอร์ดการจองรถ`,
+    );
+    setIsSubmitting(false);
+  };
+
+  return (
+    <AuthLayout
+      heading="ยินดีต้อนรับกลับสู่ระบบ"
+      subheading="จัดการคำขอจองรถ อนุมัติการใช้งาน และติดตามการเดินทางได้ง่ายในที่เดียว"
+      description="ระบบรองรับการเข้าสู่ระบบทั้งสำหรับเจ้าหน้าที่ ผู้ขับรถ และผู้ดูแลระบบ เพื่อให้กระบวนการเดินรถลื่นไหลตลอดเส้นทาง"
+      footer={
+        <>
+          ยังไม่มีบัญชีใช่ไหม?{' '}
+          <Link href="/register" className="font-semibold text-primary-600 hover:text-primary-700">
+            ลงทะเบียนที่นี่
+          </Link>
+          <div className="mt-2">
+            <Link href="/reset-password" className="text-sm text-gray-500 hover:text-gray-700">
+              ลืมรหัสผ่าน?
+            </Link>
+          </div>
+        </>
+      }
+    >
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmit)} noValidate>
+        <div>
+          <label htmlFor="email" className="form-label">
+            อีเมลองค์กร
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            className="form-input"
+            placeholder="name@company.co.th"
+            {...register('email')}
+          />
+          {errors.email ? <p className="form-error">{errors.email.message}</p> : null}
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between">
+            <label htmlFor="password" className="form-label">
+              รหัสผ่าน
+            </label>
+            <Link href="/reset-password" className="text-sm font-medium text-primary-600 hover:text-primary-700">
+              ลืมรหัสผ่าน?
+            </Link>
+          </div>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            className="form-input"
+            placeholder="กรอกรหัสผ่านของคุณ"
+            {...register('password')}
+          />
+          {errors.password ? <p className="form-error">{errors.password.message}</p> : null}
+        </div>
+
+        <div className="flex items-center justify-between">
+          <label className="inline-flex items-center gap-2 text-sm text-gray-600">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              {...register('remember')}
+            />
+            จดจำการเข้าสู่ระบบในอุปกรณ์นี้
+          </label>
+          <span className="text-xs text-gray-400">เข้ารหัสด้วยมาตรฐาน OAuth 2.0</span>
+        </div>
+
+        <button
+          type="submit"
+          className="btn-primary flex w-full items-center justify-center gap-2 py-3 text-base"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'กำลังตรวจสอบ...' : 'เข้าสู่ระบบ'}
+        </button>
+
+        {submissionMessage ? (
+          <div className="rounded-lg bg-success-50 p-4 text-sm text-success-700">{submissionMessage}</div>
+        ) : null}
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from 'next/link';
 import { FormEvent, useState } from 'react';
 
 import { NotificationCenter } from '../components/notifications/NotificationCenter';
@@ -31,8 +32,12 @@ export default function HomePage() {
               </p>
 
               <div className="mt-6 grid gap-3 sm:grid-cols-2">
-                <button className="btn-primary py-3">เข้าสู่ระบบ</button>
-                <button className="btn-secondary py-3">ดูคู่มือการใช้งาน</button>
+                <Link href="/login" className="btn-primary py-3 text-center">
+                  เข้าสู่ระบบ
+                </Link>
+                <Link href="/register" className="btn-secondary py-3 text-center">
+                  ลงทะเบียนใช้งาน
+                </Link>
               </div>
             </div>
 

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { AuthLayout } from '@/components/auth/AuthLayout';
+
+const registrationSchema = z
+  .object({
+    fullName: z.string().min(3, 'กรุณากรอกชื่อ-นามสกุล'),
+    email: z.string().email('รูปแบบอีเมลไม่ถูกต้อง'),
+    password: z
+      .string()
+      .min(8, 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร')
+      .regex(/^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).+$/, 'ต้องมีตัวใหญ่ ตัวเล็ก และตัวเลขอย่างน้อยอย่างละ 1 ตัว'),
+    confirmPassword: z.string(),
+    role: z.enum(['employee', 'driver', 'admin'], { required_error: 'กรุณาเลือกบทบาทการใช้งาน' }),
+    acceptPolicies: z
+      .boolean()
+      .refine((value) => value, {
+        message: 'กรุณายืนยันว่าคุณได้อ่านและยอมรับนโยบายการใช้งาน',
+      }),
+  })
+  .refine((values) => values.password === values.confirmPassword, {
+    message: 'รหัสผ่านยืนยันไม่ตรงกัน',
+    path: ['confirmPassword'],
+  });
+
+type RegistrationFormValues = z.infer<typeof registrationSchema>;
+
+const roleDescriptions: Record<RegistrationFormValues['role'], string> = {
+  employee: 'ขอจองรถ ติดตามสถานะ และจัดการการเดินทางของทีมได้สะดวก',
+  driver: 'รับมอบหมายงานขับรถ ดูตารางเดินรถ และรายงานสถานะได้ทันที',
+  admin: 'กำหนดสิทธิ์ผู้ใช้งาน จัดการรถ และตรวจสอบรายงานทั้งหมดในระบบ',
+};
+
+export default function RegisterPage() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<RegistrationFormValues>({
+    resolver: zodResolver(registrationSchema),
+    defaultValues: {
+      fullName: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+      role: 'employee',
+      acceptPolicies: false,
+    },
+  });
+
+  const selectedRole = watch('role');
+
+  const onSubmit = async (values: RegistrationFormValues) => {
+    setIsSubmitting(true);
+    setSuccessMessage(null);
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    setSuccessMessage(
+      `บัญชีของ ${values.fullName} ถูกสร้างเรียบร้อยแล้ว ระบบได้ส่งอีเมลยืนยันไปยัง ${values.email} และกำหนดบทบาทเป็น ${roleDescriptions[values.role]}`,
+    );
+    setIsSubmitting(false);
+  };
+
+  return (
+    <AuthLayout
+      heading="สร้างบัญชีผู้ใช้งานใหม่"
+      subheading="ขับเคลื่อนการจัดการรถขององค์กรด้วยระบบที่ปลอดภัยและออกแบบมาสำหรับการทำงานร่วมกัน"
+      description="การลงทะเบียนรองรับทั้งพนักงานทั่วไป คนขับรถ และผู้ดูแลระบบ เพื่อให้การมอบหมายงานและการอนุมัติเป็นเรื่องง่ายตั้งแต่วันแรก"
+      footer={
+        <>
+          มีบัญชีอยู่แล้วใช่ไหม?{' '}
+          <Link href="/login" className="font-semibold text-primary-600 hover:text-primary-700">
+            เข้าสู่ระบบ
+          </Link>
+        </>
+      }
+    >
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmit)} noValidate>
+        <div className="grid gap-6 sm:grid-cols-2">
+          <div>
+            <label htmlFor="fullName" className="form-label">
+              ชื่อ-นามสกุล
+            </label>
+            <input
+              id="fullName"
+              type="text"
+              className="form-input"
+              placeholder="กรุณากรอกชื่อ-นามสกุล"
+              {...register('fullName')}
+            />
+            {errors.fullName ? <p className="form-error">{errors.fullName.message}</p> : null}
+          </div>
+
+          <div>
+            <label htmlFor="email" className="form-label">
+              อีเมลองค์กร
+            </label>
+            <input
+              id="email"
+              type="email"
+              className="form-input"
+              placeholder="name@company.co.th"
+              {...register('email')}
+            />
+            {errors.email ? <p className="form-error">{errors.email.message}</p> : null}
+          </div>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-2">
+          <div>
+            <label htmlFor="password" className="form-label">
+              รหัสผ่าน
+            </label>
+            <input
+              id="password"
+              type="password"
+              className="form-input"
+              placeholder="อย่างน้อย 8 ตัวอักษร"
+              {...register('password')}
+            />
+            {errors.password ? <p className="form-error">{errors.password.message}</p> : null}
+          </div>
+
+          <div>
+            <label htmlFor="confirmPassword" className="form-label">
+              ยืนยันรหัสผ่าน
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              className="form-input"
+              placeholder="พิมพ์รหัสผ่านอีกครั้ง"
+              {...register('confirmPassword')}
+            />
+            {errors.confirmPassword ? <p className="form-error">{errors.confirmPassword.message}</p> : null}
+          </div>
+        </div>
+
+        <div>
+          <span className="form-label">เลือกบทบาทในการใช้งาน</span>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {(
+              [
+                { value: 'employee', label: 'พนักงาน' },
+                { value: 'driver', label: 'คนขับรถ' },
+                { value: 'admin', label: 'ผู้ดูแลระบบ' },
+              ] as const
+            ).map((role) => (
+              <label
+                key={role.value}
+                className={`flex cursor-pointer flex-col gap-2 rounded-lg border p-4 transition-all ${
+                  selectedRole === role.value
+                    ? 'border-primary-500 bg-primary-50 shadow-sm'
+                    : 'border-gray-200 bg-white hover:border-primary-300'
+                }`}
+              >
+                <input
+                  type="radio"
+                  value={role.value}
+                  className="sr-only"
+                  {...register('role')}
+                />
+                <span className="text-sm font-semibold text-gray-900">{role.label}</span>
+                <span className="text-xs text-gray-500">{roleDescriptions[role.value]}</span>
+              </label>
+            ))}
+          </div>
+          {errors.role ? <p className="form-error">{errors.role.message}</p> : null}
+        </div>
+
+        <div className="rounded-lg bg-gray-50 p-4 text-sm text-gray-600">
+          <p className="font-medium text-gray-900">ข้อกำหนดด้านความปลอดภัย</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            <li>ตั้งรหัสผ่านอย่างน้อย 8 ตัวอักษร และประกอบด้วยตัวเลข ตัวพิมพ์ใหญ่ และตัวพิมพ์เล็ก</li>
+            <li>ผู้ใช้งานบทบาทผู้ดูแลระบบต้องเปิดใช้งานการยืนยันตัวตนสองชั้น (2FA)</li>
+            <li>ระบบจะส่งอีเมลยืนยันเพื่อเปิดใช้งานบัญชีก่อนใช้งานจริง</li>
+          </ul>
+        </div>
+
+        <label className="flex items-start gap-3 text-sm text-gray-600">
+          <input
+            type="checkbox"
+            className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+            {...register('acceptPolicies')}
+          />
+          <span>
+            ข้าพเจ้ายอมรับ{' '}
+            <Link href="#" className="font-medium text-primary-600 hover:text-primary-700">
+              เงื่อนไขการใช้งานและนโยบายความเป็นส่วนตัวของระบบการจองรถ
+            </Link>
+          </span>
+        </label>
+        {errors.acceptPolicies ? <p className="form-error">{errors.acceptPolicies.message}</p> : null}
+
+        <button
+          type="submit"
+          className="btn-primary flex w-full items-center justify-center gap-2 py-3 text-base"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'กำลังสร้างบัญชี...' : 'ลงทะเบียน'}
+        </button>
+
+        {successMessage ? (
+          <div className="rounded-lg bg-success-50 p-4 text-sm text-success-700">{successMessage}</div>
+        ) : null}
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { AuthLayout } from '@/components/auth/AuthLayout';
+
+const resetSchema = z.object({
+  email: z.string().email('กรุณากรอกอีเมลที่ถูกต้อง'),
+  method: z.enum(['email', 'sms']),
+});
+
+type ResetFormValues = z.infer<typeof resetSchema>;
+
+export default function ResetPasswordPage() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<ResetFormValues>({
+    resolver: zodResolver(resetSchema),
+    defaultValues: {
+      email: '',
+      method: 'email',
+    },
+  });
+
+  const selectedMethod = watch('method');
+
+  const onSubmit = async (values: ResetFormValues) => {
+    setIsSubmitting(true);
+    setSuccessMessage(null);
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    setSuccessMessage(
+      values.method === 'email'
+        ? `ลิงก์สำหรับตั้งรหัสผ่านใหม่ถูกส่งไปยัง ${values.email} แล้ว`
+        : `รหัสยืนยัน 6 หลักถูกส่งไปยังหมายเลขโทรศัพท์ที่ผูกกับบัญชี ${values.email} แล้ว`,
+    );
+    setIsSubmitting(false);
+  };
+
+  return (
+    <AuthLayout
+      heading="รีเซ็ตรหัสผ่านอย่างปลอดภัย"
+      subheading="เลือกรับลิงก์รีเซ็ตผ่านอีเมลหรือรับรหัส OTP ทางโทรศัพท์ เพื่อให้คุณกลับเข้าสู่ระบบได้อย่างรวดเร็ว"
+      description="เพื่อความปลอดภัย ระบบจะบันทึกประวัติการรีเซ็ตรหัสผ่านและแจ้งเตือนผู้ดูแลระบบเมื่อเกิดเหตุการณ์ผิดปกติ"
+      footer={
+        <>
+          จำรหัสผ่านได้แล้วใช่ไหม?{' '}
+          <Link href="/login" className="font-semibold text-primary-600 hover:text-primary-700">
+            กลับไปเข้าสู่ระบบ
+          </Link>
+        </>
+      }
+    >
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmit)} noValidate>
+        <div>
+          <label htmlFor="email" className="form-label">
+            อีเมลที่ใช้สมัคร
+          </label>
+          <input
+            id="email"
+            type="email"
+            className="form-input"
+            placeholder="name@company.co.th"
+            {...register('email')}
+          />
+          {errors.email ? <p className="form-error">{errors.email.message}</p> : null}
+        </div>
+
+        <div>
+          <span className="form-label">เลือกรูปแบบการยืนยันตัวตน</span>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {(
+              [
+                { value: 'email', label: 'อีเมล', description: 'ส่งลิงก์รีเซ็ตไปยังกล่องจดหมายองค์กรของคุณ' },
+                { value: 'sms', label: 'SMS OTP', description: 'รับรหัสยืนยัน 6 หลักผ่านหมายเลขโทรศัพท์ที่ผูกกับบัญชี' },
+              ] as const
+            ).map((method) => (
+              <label
+                key={method.value}
+                className={`flex cursor-pointer flex-col gap-2 rounded-lg border p-4 transition-all ${
+                  selectedMethod === method.value
+                    ? 'border-primary-500 bg-primary-50 shadow-sm'
+                    : 'border-gray-200 bg-white hover:border-primary-300'
+                }`}
+              >
+                <input
+                  type="radio"
+                  value={method.value}
+                  className="sr-only"
+                  {...register('method')}
+                />
+                <span className="text-sm font-semibold text-gray-900">{method.label}</span>
+                <span className="text-xs text-gray-500">{method.description}</span>
+              </label>
+            ))}
+          </div>
+          {errors.method ? <p className="form-error">{errors.method.message}</p> : null}
+        </div>
+
+        <div className="rounded-lg bg-secondary-50 p-4 text-sm text-secondary-900">
+          <p className="font-semibold">คำแนะนำ</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            <li>สำหรับบทบาทผู้ดูแลระบบ จะต้องยืนยันรหัส OTP ก่อนจึงจะตั้งรหัสผ่านใหม่ได้</li>
+            <li>หากไม่ได้รับอีเมลภายใน 5 นาที กรุณาตรวจสอบในโฟลเดอร์ Junk หรือ Spam</li>
+            <li>การรีเซ็ตรหัสผ่านมากกว่า 3 ครั้งใน 24 ชั่วโมงจะถูกแจ้งเตือนผู้ดูแลระบบอัตโนมัติ</li>
+          </ul>
+        </div>
+
+        <button
+          type="submit"
+          className="btn-primary flex w-full items-center justify-center gap-2 py-3 text-base"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'กำลังส่งลิงก์รีเซ็ต...' : 'ส่งคำขอรีเซ็ตรหัสผ่าน'}
+        </button>
+
+        {successMessage ? (
+          <div className="rounded-lg bg-success-50 p-4 text-sm text-success-700">{successMessage}</div>
+        ) : null}
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/components/auth/AuthLayout.tsx
+++ b/frontend/src/components/auth/AuthLayout.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { ShieldCheck, Users, Bell } from 'lucide-react';
+
+interface HighlightItem {
+  title: string;
+  description: string;
+  icon: ReactNode;
+}
+
+interface AuthLayoutProps {
+  heading: string;
+  subheading: string;
+  description?: string;
+  highlights?: HighlightItem[];
+  children: ReactNode;
+  footer?: ReactNode;
+}
+
+const defaultHighlights: HighlightItem[] = [
+  {
+    title: 'การอนุมัติหลายระดับ',
+    description: 'รองรับการอนุมัติจากหัวหน้างาน ผู้จัดการ และผู้ดูแลระบบในระบบเดียว',
+    icon: <ShieldCheck className="h-6 w-6 text-primary-500" aria-hidden="true" />,
+  },
+  {
+    title: 'จัดการผู้ใช้งานง่าย',
+    description: 'กำหนดบทบาทและสิทธิ์การเข้าถึงได้อย่างยืดหยุ่นตามโครงสร้างองค์กร',
+    icon: <Users className="h-6 w-6 text-primary-500" aria-hidden="true" />,
+  },
+  {
+    title: 'แจ้งเตือนทันที',
+    description: 'รับการแจ้งเตือนผ่านอีเมล WebSocket และ Mobile App เพื่อไม่ให้พลาดทุกการอนุมัติ',
+    icon: <Bell className="h-6 w-6 text-primary-500" aria-hidden="true" />,
+  },
+];
+
+export function AuthLayout({
+  heading,
+  subheading,
+  description,
+  highlights = defaultHighlights,
+  children,
+  footer,
+}: AuthLayoutProps) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-secondary-100">
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col justify-center px-4 py-12 lg:flex-row lg:items-center lg:gap-16">
+        <section className="max-w-xl text-center lg:text-left">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full bg-primary-100 px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary-700"
+          >
+            Office Vehicle Booking
+          </Link>
+          <h1 className="mt-6 text-4xl font-bold text-gray-900 sm:text-5xl">{heading}</h1>
+          <p className="mt-4 text-lg text-gray-600">{subheading}</p>
+          {description ? <p className="mt-3 text-sm text-gray-500">{description}</p> : null}
+
+          <dl className="mt-10 grid gap-6 sm:grid-cols-2">
+            {highlights.map((item) => (
+              <div key={item.title} className="rounded-2xl bg-white/70 p-5 text-left shadow-sm ring-1 ring-gray-100 backdrop-blur">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50">
+                    {item.icon}
+                  </div>
+                  <div>
+                    <dt className="text-base font-semibold text-gray-900">{item.title}</dt>
+                    <dd className="mt-1 text-sm text-gray-600">{item.description}</dd>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section className="mt-12 w-full max-w-md lg:mt-0">
+          <div className="card relative overflow-hidden">
+            <div className="absolute inset-x-6 top-0 h-1 rounded-b-full bg-gradient-to-r from-primary-400 via-secondary-400 to-primary-500" />
+            <div className="mt-6">{children}</div>
+          </div>
+          {footer ? <div className="mt-6 text-center text-sm text-gray-600">{footer}</div> : null}
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable authentication layout with marketing highlights
- create login, registration, and password reset pages with form validation and role handling
- build an admin 2FA setup and verification experience and update the landing page CTAs

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68ca58854dc8832884d22c9965613c0c