### PR TITLE
Implement session management and protected profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/app/admin/2fa/page.tsx
+++ b/frontend/src/app/admin/2fa/page.tsx
@@ -6,6 +6,8 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { AuthLayout } from '@/components/auth/AuthLayout';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { USER_ROLES } from '@/context/AuthContext';
 import { CheckCircle2, Copy, RefreshCw, ShieldAlert, Smartphone } from 'lucide-react';
 
 type TwoFactorMethod = 'authenticator' | 'sms';
@@ -45,7 +47,7 @@ function generateSecretKey() {
   return Math.random().toString(36).slice(2, 10).toUpperCase();
 }
 
-export default function AdminTwoFactorPage() {
+function AdminTwoFactorContent() {
   const [selectedMethod, setSelectedMethod] = useState<TwoFactorMethod>('authenticator');
   const [secretKey, setSecretKey] = useState(() => generateSecretKey());
   const [backupCodes, setBackupCodes] = useState(() => generateBackupCodes());
@@ -275,5 +277,13 @@ export default function AdminTwoFactorPage() {
         </section>
       </div>
     </AuthLayout>
+  );
+}
+
+export default function AdminTwoFactorPage() {
+  return (
+    <ProtectedRoute roles={[USER_ROLES.FLEET_ADMIN, USER_ROLES.MANAGER]}>
+      <AdminTwoFactorContent />
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import Providers from './providers';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -24,7 +25,9 @@ export default function RootLayout({
   return (
     <html lang="th">
       <body className={inter.className}>
-        <div id="root">{children}</div>
+        <Providers>
+          <div id="root">{children}</div>
+        </Providers>
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,18 +1,50 @@
 "use client";
 
 import Link from 'next/link';
-import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
-import { NotificationCenter } from '../components/notifications/NotificationCenter';
+import { NotificationCenter } from '@/components/notifications/NotificationCenter';
+import { useAuth } from '@/context/AuthContext';
 
 export default function HomePage() {
-  const [tokenInput, setTokenInput] = useState('');
-  const [activeToken, setActiveToken] = useState<string | null>(null);
+  const router = useRouter();
+  const { isAuthenticated, user, logout } = useAuth();
 
-  const handleConnect = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setActiveToken(tokenInput.trim() || null);
+  const handleLogout = () => {
+    logout();
+    router.push('/');
   };
+
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50">
+        <div className="container mx-auto px-4 py-16">
+          <div className="grid gap-8 lg:grid-cols-[2fr_3fr]">
+            <div className="space-y-6">
+              <div className="rounded-2xl bg-white p-8 shadow-lg">
+                <h1 className="text-4xl font-bold text-gray-900">ระบบจองรถสำนักงาน</h1>
+                <p className="mt-3 text-xl text-gray-600">Office Vehicle Booking System</p>
+                <p className="mt-4 text-sm text-gray-500">
+                  แพลตฟอร์มบริหารจัดการการขอใช้รถสำหรับองค์กร พร้อมระบบอนุมัติหลายขั้นตอน การติดตามสถานะ และการแจ้งเตือนหลากหลายช่องทาง
+                </p>
+
+                <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                  <Link href="/login" className="btn-primary py-3 text-center">
+                    เข้าสู่ระบบ
+                  </Link>
+                  <Link href="/register" className="btn-secondary py-3 text-center">
+                    ลงทะเบียนใช้งาน
+                  </Link>
+                </div>
+              </div>
+            </div>
+
+            <NotificationCenter />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50">
@@ -20,70 +52,30 @@ export default function HomePage() {
         <div className="grid gap-8 lg:grid-cols-[2fr_3fr]">
           <div className="space-y-6">
             <div className="rounded-2xl bg-white p-8 shadow-lg">
-              <h1 className="text-4xl font-bold text-gray-900">
-                ระบบจองรถสำนักงาน
-              </h1>
-              <p className="mt-3 text-xl text-gray-600">
-                Office Vehicle Booking System
-              </p>
-              <p className="mt-4 text-sm text-gray-500">
-                แพลตฟอร์มบริหารจัดการการขอใช้รถสำหรับองค์กร พร้อมระบบอนุมัติหลายขั้นตอน
-                การติดตามสถานะ และการแจ้งเตือนหลากหลายช่องทาง
-              </p>
-
-              <div className="mt-6 grid gap-3 sm:grid-cols-2">
-                <Link href="/login" className="btn-primary py-3 text-center">
-                  เข้าสู่ระบบ
-                </Link>
-                <Link href="/register" className="btn-secondary py-3 text-center">
-                  ลงทะเบียนใช้งาน
-                </Link>
-              </div>
-            </div>
-
-            <form
-              onSubmit={handleConnect}
-              className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
-            >
-              <h2 className="text-xl font-semibold text-gray-900">
-                เชื่อมต่อศูนย์แจ้งเตือนแบบเรียลไทม์
-              </h2>
-              <p className="mt-2 text-sm text-gray-500">
-                วาง JWT Access Token ของคุณเพื่อรับการแจ้งเตือนแบบทันทีผ่าน WebSocket
-              </p>
-              <div className="mt-4 space-y-3">
-                <input
-                  type="text"
-                  value={tokenInput}
-                  onChange={(event) => setTokenInput(event.target.value)}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
-                  placeholder="ใส่ Access Token"
-                />
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="submit"
-                    className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
-                  >
-                    เชื่อมต่อศูนย์แจ้งเตือน
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-sm uppercase tracking-wide text-primary-500">พร้อมใช้งาน</p>
+                  <h1 className="mt-1 text-3xl font-bold text-gray-900">ยินดีต้อนรับกลับ {user?.fullName}</h1>
+                  <p className="mt-2 text-sm text-gray-500">
+                    บทบาทของคุณ: <span className="font-semibold text-gray-700">{user?.role}</span>
+                  </p>
+                </div>
+                <div className="flex gap-3">
+                  <Link href="/profile" className="btn-secondary whitespace-nowrap px-4 py-2">
+                    จัดการโปรไฟล์
+                  </Link>
+                  <button type="button" onClick={handleLogout} className="btn-outline whitespace-nowrap px-4 py-2">
+                    ออกจากระบบ
                   </button>
-                  <button
-                    type="button"
-                    onClick={() => setActiveToken(null)}
-                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
-                  >
-                    ยกเลิกการเชื่อมต่อ
-                  </button>
-                  {activeToken ? (
-                    <span className="text-sm text-green-600">เชื่อมต่อเรียบร้อย</span>
-                  ) : (
-                    <span className="text-sm text-gray-400">ยังไม่ได้เชื่อมต่อ</span>
-                  )}
                 </div>
               </div>
-            </form>
+              <p className="mt-6 text-sm text-gray-600">
+                ตรวจสอบการแจ้งเตือนล่าสุดและติดตามสถานะคำขอจองรถของคุณได้ทันที ระบบจะต่ออายุการเข้าสู่ระบบให้อัตโนมัติเมื่อโทเคนใกล้หมดอายุเพื่อให้คุณใช้งานได้อย่างต่อเนื่อง
+              </p>
+            </div>
           </div>
 
-          <NotificationCenter authToken={activeToken} />
+          <NotificationCenter />
         </div>
       </div>
     </div>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { useAuth } from '@/context/AuthContext';
+
+const profileSchema = z.object({
+  fullName: z.string().min(1, 'กรุณากรอกชื่อ-นามสกุล'),
+  email: z.string().email('รูปแบบอีเมลไม่ถูกต้อง'),
+  department: z
+    .string()
+    .max(100, 'แผนกต้องไม่เกิน 100 ตัวอักษร')
+    .optional()
+    .transform((value) => value ?? ''),
+  twoFactorEnabled: z.boolean(),
+});
+
+type ProfileFormValues = z.infer<typeof profileSchema>;
+
+function ProfileContent() {
+  const { user, updateProfile } = useAuth();
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [statusVariant, setStatusVariant] = useState<'success' | 'error'>('success');
+  const [saving, setSaving] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      fullName: user?.fullName ?? '',
+      email: user?.email ?? '',
+      department: user?.department ?? '',
+      twoFactorEnabled: user?.twoFactorEnabled ?? false,
+    },
+  });
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+    reset({
+      fullName: user.fullName,
+      email: user.email,
+      department: user.department ?? '',
+      twoFactorEnabled: user.twoFactorEnabled,
+    });
+  }, [reset, user]);
+
+  const onSubmit = async (values: ProfileFormValues) => {
+    setSaving(true);
+    setStatusMessage(null);
+    try {
+      await updateProfile({
+        fullName: values.fullName.trim(),
+        email: values.email.trim(),
+        department: values.department?.trim() ? values.department.trim() : null,
+        twoFactorEnabled: values.twoFactorEnabled,
+      });
+      setStatusVariant('success');
+      setStatusMessage('บันทึกการปรับปรุงโปรไฟล์เรียบร้อยแล้ว');
+    } catch (error: unknown) {
+      setStatusVariant('error');
+      const message = error instanceof Error ? error.message : 'ไม่สามารถบันทึกการเปลี่ยนแปลงได้';
+      setStatusMessage(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 py-10">
+      <div className="container mx-auto px-4">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">โปรไฟล์ผู้ใช้งาน</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            จัดการข้อมูลส่วนตัวของคุณและตรวจสอบสถานะเซสชัน ระบบจะออกจากระบบให้อัตโนมัติเมื่อโทเคนหมดอายุเพื่อความปลอดภัยสูงสุด
+          </p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
+          <div className="space-y-6">
+            <div className="rounded-xl bg-white p-6 shadow-sm">
+              <h2 className="text-xl font-semibold text-gray-900">ข้อมูลส่วนบุคคล</h2>
+              <p className="mt-1 text-sm text-gray-500">อัปเดตรายละเอียดของคุณเพื่อให้การประสานงานเป็นไปอย่างราบรื่น</p>
+
+              <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-5">
+                <div>
+                  <label htmlFor="fullName" className="form-label">
+                    ชื่อ-นามสกุล
+                  </label>
+                  <input
+                    id="fullName"
+                    type="text"
+                    className="form-input"
+                    placeholder="เช่น สมชาย ใจดี"
+                    {...register('fullName')}
+                  />
+                  {errors.fullName ? <p className="form-error">{errors.fullName.message}</p> : null}
+                </div>
+
+                <div>
+                  <label htmlFor="email" className="form-label">
+                    อีเมลองค์กร
+                  </label>
+                  <input
+                    id="email"
+                    type="email"
+                    className="form-input"
+                    placeholder="name@company.co.th"
+                    {...register('email')}
+                  />
+                  {errors.email ? <p className="form-error">{errors.email.message}</p> : null}
+                </div>
+
+                <div>
+                  <label htmlFor="department" className="form-label">
+                    แผนก / หน่วยงาน
+                  </label>
+                  <input
+                    id="department"
+                    type="text"
+                    className="form-input"
+                    placeholder="เช่น ฝ่ายธุรการ"
+                    {...register('department')}
+                  />
+                  {errors.department ? <p className="form-error">{errors.department.message}</p> : null}
+                </div>
+
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                  <label className="flex items-start gap-3">
+                    <input
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      {...register('twoFactorEnabled')}
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-gray-900">เปิดใช้งานการยืนยันตัวตนสองขั้นตอน</span>
+                      <span className="mt-1 block text-xs text-gray-500">
+                        เมื่อเปิดใช้งาน ระบบจะขอรหัสยืนยันเพิ่มเติมระหว่างการเข้าสู่ระบบ เพื่อป้องกันการเข้าถึงโดยไม่ได้รับอนุญาต
+                      </span>
+                    </span>
+                  </label>
+                </div>
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <button
+                    type="submit"
+                    className="btn-primary px-6 py-2"
+                    disabled={saving || !isDirty}
+                  >
+                    {saving ? 'กำลังบันทึก...' : 'บันทึกการเปลี่ยนแปลง'}
+                  </button>
+                  {statusMessage ? (
+                    <span
+                      className={
+                        statusVariant === 'success'
+                          ? 'text-sm text-success-600'
+                          : 'text-sm text-red-600'
+                      }
+                    >
+                      {statusMessage}
+                    </span>
+                  ) : null}
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <aside className="space-y-6">
+            <div className="rounded-xl bg-white p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-gray-900">สรุปบัญชี</h3>
+              <dl className="mt-4 space-y-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <dt className="text-gray-500">ชื่อผู้ใช้</dt>
+                  <dd className="font-medium text-gray-900">{user?.username}</dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-gray-500">บทบาท</dt>
+                  <dd className="font-medium text-gray-900">{user?.role}</dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-gray-500">สถานะ</dt>
+                  <dd className="font-medium text-gray-900">
+                    {user?.isActive ? 'ใช้งานอยู่' : 'ถูกระงับการใช้งาน'}
+                  </dd>
+                </div>
+                <div className="flex items-start justify-between gap-3">
+                  <dt className="text-gray-500">การยืนยัน 2 ขั้นตอน</dt>
+                  <dd className="text-right font-medium text-gray-900">
+                    {user?.twoFactorEnabled ? 'เปิดใช้งาน' : 'ปิดอยู่'}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="rounded-xl border border-primary-200 bg-primary-50 p-6 text-sm text-primary-800">
+              <h4 className="text-base font-semibold text-primary-700">การจัดการเซสชัน</h4>
+              <p className="mt-2">
+                โทเคนการเข้าสู่ระบบจะถูกจัดเก็บอย่างปลอดภัยและต่ออายุให้โดยอัตโนมัติก่อนหมดอายุ
+                หากระบบไม่สามารถต่ออายุได้ คุณจะถูกออกจากระบบโดยอัตโนมัติเพื่อป้องกันความเสี่ยง
+              </p>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ProfilePage() {
+  return (
+    <ProtectedRoute>
+      <ProfileContent />
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { AuthProvider } from '@/context/AuthContext';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+export default Providers;

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { useAuth, UserRole } from '@/context/AuthContext';
+
+interface ProtectedRouteProps {
+  roles?: UserRole[];
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function ProtectedRoute({ roles, fallback, children }: ProtectedRouteProps) {
+  const router = useRouter();
+  const { isAuthenticated, initializing, user } = useAuth();
+
+  useEffect(() => {
+    if (initializing) {
+      return;
+    }
+
+    if (!isAuthenticated) {
+      router.replace('/login');
+      return;
+    }
+
+    if (roles && roles.length > 0 && user && !roles.includes(user.role)) {
+      router.replace('/');
+    }
+  }, [initializing, isAuthenticated, roles, router, user]);
+
+  if (initializing) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <p className="text-sm text-gray-500">กำลังตรวจสอบสิทธิ์การเข้าใช้งาน...</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return fallback ? <>{fallback}</> : null;
+  }
+
+  if (roles && roles.length > 0 && user && !roles.includes(user.role)) {
+    return (
+      fallback ?? (
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <div className="rounded-lg border border-red-200 bg-red-50 px-6 py-4 text-sm text-red-700">
+            คุณไม่มีสิทธิ์เข้าถึงหน้าดังกล่าว
+          </div>
+        </div>
+      )
+    );
+  }
+
+  return <>{children}</>;
+}
+
+export default ProtectedRoute;

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -2,15 +2,14 @@
 
 import { FormEvent, useState } from 'react';
 
+import { useAuth } from '@/context/AuthContext';
+
 import { NotificationHistoryList } from './NotificationHistoryList';
 import { NotificationPreferencesForm } from './NotificationPreferencesForm';
 import { useNotificationCenter } from './useNotificationCenter';
 
-interface NotificationCenterProps {
-  authToken: string | null;
-}
-
-export function NotificationCenter({ authToken }: NotificationCenterProps) {
+export function NotificationCenter() {
+  const { isAuthenticated } = useAuth();
   const {
     notifications,
     preferences,
@@ -22,14 +21,14 @@ export function NotificationCenter({ authToken }: NotificationCenterProps) {
     markAllRead,
     updatePreferences,
     sendTestNotification,
-  } = useNotificationCenter(authToken);
+  } = useNotificationCenter();
 
   const [testTitle, setTestTitle] = useState('ทดสอบระบบแจ้งเตือน');
   const [testMessage, setTestMessage] = useState('นี่คือข้อความตัวอย่างสำหรับตรวจสอบการตั้งค่า');
   const [sendingTest, setSendingTest] = useState(false);
   const [testStatus, setTestStatus] = useState<string | null>(null);
 
-  if (!authToken) {
+  if (!isAuthenticated) {
     return (
       <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center shadow-sm">
         <h3 className="text-lg font-semibold text-gray-900">เข้าสู่ระบบเพื่อดูการแจ้งเตือน</h3>
@@ -47,8 +46,9 @@ export function NotificationCenter({ authToken }: NotificationCenterProps) {
     try {
       await sendTestNotification(testTitle, testMessage);
       setTestStatus('ส่งข้อความทดสอบเรียบร้อยแล้ว');
-    } catch (err: any) {
-      setTestStatus(err.message ?? 'ไม่สามารถส่งข้อความทดสอบ');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'ไม่สามารถส่งข้อความทดสอบ';
+      setTestStatus(message);
     } finally {
       setSendingTest(false);
     }

--- a/frontend/src/components/notifications/NotificationPreferencesForm.tsx
+++ b/frontend/src/components/notifications/NotificationPreferencesForm.tsx
@@ -26,8 +26,9 @@ export function NotificationPreferencesForm({
     try {
       await onUpdate({ [field]: value } as PreferencesUpdatePayload);
       setStatus('บันทึกการตั้งค่าเรียบร้อยแล้ว');
-    } catch (err: any) {
-      setStatus(err.message ?? 'เกิดข้อผิดพลาดในการบันทึก');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'เกิดข้อผิดพลาดในการบันทึก';
+      setStatus(message);
     } finally {
       setSaving(false);
     }
@@ -41,8 +42,9 @@ export function NotificationPreferencesForm({
       await onUpdate({ line_access_token: lineToken || null });
       setLineToken('');
       setStatus('อัปเดต LINE Notify token สำเร็จ');
-    } catch (err: any) {
-      setStatus(err.message ?? 'ไม่สามารถอัปเดต LINE token');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'ไม่สามารถอัปเดต LINE token';
+      setStatus(message);
     } finally {
       setSaving(false);
     }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,449 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  SessionPersistence,
+  StoredSession,
+  clearStoredSession,
+  loadStoredSession,
+  saveStoredSession,
+} from '@/lib/auth/storage';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+const REFRESH_MARGIN_MS = 60_000; // refresh 60 seconds before expiry
+
+export const USER_ROLES = {
+  REQUESTER: 'requester',
+  MANAGER: 'manager',
+  FLEET_ADMIN: 'fleet_admin',
+  DRIVER: 'driver',
+  AUDITOR: 'auditor',
+} as const;
+
+export type UserRole = (typeof USER_ROLES)[keyof typeof USER_ROLES];
+
+export interface AuthUser {
+  id: number;
+  username: string;
+  email: string;
+  fullName: string;
+  department: string | null;
+  role: UserRole;
+  isActive: boolean;
+  twoFactorEnabled: boolean;
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: number | null;
+  persist: SessionPersistence | null;
+  initializing: boolean;
+}
+
+interface LoginPayload {
+  username: string;
+  password: string;
+  remember?: boolean;
+}
+
+interface ProfileUpdatePayload {
+  fullName?: string;
+  email?: string;
+  department?: string | null;
+  twoFactorEnabled?: boolean;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  accessToken: string | null;
+  isAuthenticated: boolean;
+  initializing: boolean;
+  login: (payload: LoginPayload) => Promise<void>;
+  logout: () => void;
+  refreshAccessToken: () => Promise<string | null>;
+  updateProfile: (payload: ProfileUpdatePayload) => Promise<AuthUser>;
+  authenticatedFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function normaliseUser(payload: UserResponse): AuthUser {
+  return {
+    id: payload.id,
+    username: payload.username,
+    email: payload.email,
+    fullName: payload.full_name,
+    department: payload.department ?? null,
+    role: payload.role,
+    isActive: payload.is_active,
+    twoFactorEnabled: payload.two_fa_enabled,
+  };
+}
+
+async function requestLogin(username: string, password: string) {
+  const response = await fetch(`${API_URL}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const message = typeof data?.detail === 'string' ? data.detail : 'ไม่สามารถเข้าสู่ระบบได้';
+    throw new Error(message);
+  }
+
+  return response.json() as Promise<{
+    access_token: string;
+    refresh_token: string;
+    token_type: string;
+    expires_in: number;
+  }>;
+}
+
+async function requestProfile(token: string): Promise<UserResponse> {
+  const response = await fetch(`${API_URL}/api/v1/users/me`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error('ไม่สามารถโหลดข้อมูลผู้ใช้');
+  }
+  return response.json();
+}
+
+async function requestRefresh(refreshToken: string) {
+  const response = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const message = typeof data?.detail === 'string' ? data.detail : 'ไม่สามารถต่ออายุเซสชันได้';
+    throw new Error(message);
+  }
+  return response.json() as Promise<{
+    access_token: string;
+    expires_in: number;
+    token_type: string;
+    issued_at?: string;
+  }>;
+}
+
+const initialState: AuthState = {
+  user: null,
+  accessToken: null,
+  refreshToken: null,
+  expiresAt: null,
+  persist: null,
+  initializing: true,
+};
+
+interface UserResponse {
+  id: number;
+  username: string;
+  email: string;
+  full_name: string;
+  department?: string | null;
+  role: UserRole;
+  is_active: boolean;
+  two_fa_enabled: boolean;
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>(initialState);
+  const refreshPromiseRef = useRef<Promise<string | null> | null>(null);
+
+  const logout = useCallback(() => {
+    clearStoredSession();
+    setState({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      expiresAt: null,
+      persist: null,
+      initializing: false,
+    });
+  }, []);
+
+  const refreshAccessToken = useCallback(async () => {
+    if (!state.refreshToken) {
+      logout();
+      return null;
+    }
+
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current;
+    }
+
+    refreshPromiseRef.current = (async () => {
+      try {
+        const data = await requestRefresh(state.refreshToken as string);
+        const expiresAt = Date.now() + data.expires_in * 1000;
+        const persist = state.persist ?? 'local';
+        saveStoredSession(
+          {
+            accessToken: data.access_token,
+            refreshToken: state.refreshToken as string,
+            expiresAt,
+          },
+          persist,
+        );
+        setState((prev) => ({
+          ...prev,
+          accessToken: data.access_token,
+          expiresAt,
+          persist,
+        }));
+        return data.access_token;
+      } catch (error) {
+        logout();
+        throw error;
+      } finally {
+        refreshPromiseRef.current = null;
+      }
+    })();
+
+    return refreshPromiseRef.current;
+  }, [logout, state.persist, state.refreshToken]);
+
+  const authenticatedFetch = useCallback(
+    async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      if (!state.accessToken) {
+        throw new Error('ต้องเข้าสู่ระบบก่อนใช้งาน');
+      }
+
+      const headers = new Headers(init.headers ?? undefined);
+      if (!headers.has('Authorization')) {
+        headers.set('Authorization', `Bearer ${state.accessToken}`);
+      }
+
+      const body = init.body;
+      const shouldSetJson =
+        body !== undefined &&
+        !(body instanceof FormData) &&
+        !headers.has('Content-Type');
+      if (shouldSetJson) {
+        headers.set('Content-Type', 'application/json');
+      }
+
+      let response = await fetch(input, { ...init, headers });
+      if (response.status !== 401) {
+        return response;
+      }
+
+      try {
+        const newToken = await refreshAccessToken();
+        if (!newToken) {
+          return response;
+        }
+        headers.set('Authorization', `Bearer ${newToken}`);
+        response = await fetch(input, { ...init, headers });
+        if (response.status === 401) {
+          logout();
+        }
+        return response;
+      } catch (error) {
+        logout();
+        throw error;
+      }
+    },
+    [logout, refreshAccessToken, state.accessToken],
+  );
+
+  const updateProfile = useCallback(
+    async (payload: ProfileUpdatePayload) => {
+      const response = await authenticatedFetch(`${API_URL}/api/v1/users/me`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          full_name: payload.fullName,
+          email: payload.email,
+          department: payload.department,
+          two_fa_enabled: payload.twoFactorEnabled,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const message = typeof data?.detail === 'string' ? data.detail : 'ไม่สามารถอัปเดตโปรไฟล์ได้';
+        throw new Error(message);
+      }
+
+      const data = await response.json();
+      const user = normaliseUser(data);
+      setState((prev) => ({
+        ...prev,
+        user,
+      }));
+      return user;
+    },
+    [authenticatedFetch],
+  );
+
+  const initialiseFromStorage = useCallback(async () => {
+    const stored = loadStoredSession();
+    if (!stored) {
+      setState((prev) => ({ ...prev, initializing: false }));
+      return;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      accessToken: stored.accessToken,
+      refreshToken: stored.refreshToken,
+      expiresAt: stored.expiresAt,
+      persist: stored.persist,
+    }));
+
+    const loadUserWithToken = async (token: string, session: StoredSession) => {
+      const profileData = await requestProfile(token);
+      const user = normaliseUser(profileData);
+      setState({
+        user,
+        accessToken: token,
+        refreshToken: session.refreshToken,
+        expiresAt: session.expiresAt,
+        persist: session.persist,
+        initializing: false,
+      });
+    };
+
+    try {
+      if (stored.expiresAt && stored.expiresAt <= Date.now() + REFRESH_MARGIN_MS) {
+        const refreshed = await requestRefresh(stored.refreshToken);
+        const expiresAt = Date.now() + refreshed.expires_in * 1000;
+        const session: StoredSession = {
+          accessToken: refreshed.access_token,
+          refreshToken: stored.refreshToken,
+          expiresAt,
+          persist: stored.persist,
+        };
+        saveStoredSession(
+          {
+            accessToken: session.accessToken,
+            refreshToken: session.refreshToken,
+            expiresAt: session.expiresAt,
+          },
+          session.persist,
+        );
+        await loadUserWithToken(session.accessToken, session);
+      } else {
+        await loadUserWithToken(stored.accessToken, stored);
+      }
+    } catch (error) {
+      try {
+        const refreshed = await requestRefresh(stored.refreshToken);
+        const expiresAt = Date.now() + refreshed.expires_in * 1000;
+        const session: StoredSession = {
+          accessToken: refreshed.access_token,
+          refreshToken: stored.refreshToken,
+          expiresAt,
+          persist: stored.persist,
+        };
+        saveStoredSession(
+          {
+            accessToken: session.accessToken,
+            refreshToken: session.refreshToken,
+            expiresAt: session.expiresAt,
+          },
+          session.persist,
+        );
+        await loadUserWithToken(session.accessToken, session);
+      } catch (refreshError) {
+        logout();
+      }
+    }
+  }, [logout]);
+
+  useEffect(() => {
+    void initialiseFromStorage();
+  }, [initialiseFromStorage]);
+
+  useEffect(() => {
+    if (!state.accessToken || !state.refreshToken || !state.expiresAt) {
+      return;
+    }
+
+    const now = Date.now();
+    const refreshDelay = Math.max(state.expiresAt - now - REFRESH_MARGIN_MS, 1_000);
+    const expiryDelay = Math.max(state.expiresAt - now, 0);
+
+    const refreshTimer = window.setTimeout(() => {
+      void refreshAccessToken();
+    }, refreshDelay);
+
+    const expiryTimer = window.setTimeout(() => {
+      logout();
+    }, expiryDelay);
+
+    return () => {
+      window.clearTimeout(refreshTimer);
+      window.clearTimeout(expiryTimer);
+    };
+  }, [logout, refreshAccessToken, state.accessToken, state.expiresAt, state.refreshToken]);
+
+  const login = useCallback(
+    async ({ username, password, remember = true }: LoginPayload) => {
+      const data = await requestLogin(username, password);
+      const expiresAt = Date.now() + data.expires_in * 1000;
+      const persist: SessionPersistence = remember ? 'local' : 'session';
+      const session: StoredSession = {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+        expiresAt,
+        persist,
+      };
+
+      saveStoredSession(
+        {
+          accessToken: session.accessToken,
+          refreshToken: session.refreshToken,
+          expiresAt: session.expiresAt,
+        },
+        persist,
+      );
+
+      const profile = await requestProfile(session.accessToken);
+      const user = normaliseUser(profile);
+      setState({
+        user,
+        accessToken: session.accessToken,
+        refreshToken: session.refreshToken,
+        expiresAt: session.expiresAt,
+        persist,
+        initializing: false,
+      });
+    },
+    [],
+  );
+
+  const contextValue = useMemo<AuthContextValue>(
+    () => ({
+      user: state.user,
+      accessToken: state.accessToken,
+      isAuthenticated: Boolean(state.user && state.accessToken),
+      initializing: state.initializing,
+      login,
+      logout,
+      refreshAccessToken,
+      updateProfile,
+      authenticatedFetch,
+    }),
+    [authenticatedFetch, login, logout, refreshAccessToken, state.accessToken, state.initializing, state.user, updateProfile],
+  );
+
+  return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/lib/auth/storage.ts
+++ b/frontend/src/lib/auth/storage.ts
@@ -1,0 +1,70 @@
+const STORAGE_KEY = 'ovbs.session';
+
+export type SessionPersistence = 'local' | 'session';
+
+export interface StoredSession {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  persist: SessionPersistence;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function getStorage(persist: SessionPersistence): Storage {
+  return persist === 'local' ? window.localStorage : window.sessionStorage;
+}
+
+export function loadStoredSession(): StoredSession | null {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  const fromLocal = window.localStorage.getItem(STORAGE_KEY);
+  if (fromLocal) {
+    try {
+      const parsed = JSON.parse(fromLocal) as Omit<StoredSession, 'persist'>;
+      return { ...parsed, persist: 'local' };
+    } catch (error) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  const fromSession = window.sessionStorage.getItem(STORAGE_KEY);
+  if (fromSession) {
+    try {
+      const parsed = JSON.parse(fromSession) as Omit<StoredSession, 'persist'>;
+      return { ...parsed, persist: 'session' };
+    } catch (error) {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  return null;
+}
+
+export function saveStoredSession(
+  session: Omit<StoredSession, 'persist'>,
+  persist: SessionPersistence,
+): void {
+  if (!isBrowser()) {
+    return;
+  }
+
+  const target = getStorage(persist);
+  const payload = JSON.stringify(session);
+  target.setItem(STORAGE_KEY, payload);
+
+  const alternate = persist === 'local' ? window.sessionStorage : window.localStorage;
+  alternate.removeItem(STORAGE_KEY);
+}
+
+export function clearStoredSession(): void {
+  if (!isBrowser()) {
+    return;
+  }
+  window.localStorage.removeItem(STORAGE_KEY);
+  window.sessionStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- add an authentication context that stores tokens, performs refreshes, and exposes an authenticated fetch helper
- wrap the app with the new provider, update login/home flows, and add a protected profile management screen
- integrate role-aware guards for notifications and admin 2FA pages while switching notification APIs to the authenticated utilities

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68ca5a576c18832894b58675bb52323d