### PR TITLE
feat(frontend): add mobile-first PWA experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ dist
 # Gatsby files
 .cache/
 public
+!frontend/public/
+!frontend/public/**
 
 # Storybook build outputs
 .out

--- a/frontend/public/icons/app-icon-maskable.svg
+++ b/frontend/public/icons/app-icon-maskable.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="maskableGradient" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" rx="128" fill="url(#maskableGradient)" />
+  <g fill="white" stroke="white" stroke-width="18" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M128 320h256c35.3 0 64 28.7 64 64v32c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32v-32c0-35.3 28.7-64 64-64z" fill-opacity="0.2" />
+    <path d="M160 332l40-136c8.4-28.5 34.3-48 64.1-48h43.8c29.7 0 55.6 19.5 64.1 48l40 136H160z" fill="none" />
+    <circle cx="200" cy="400" r="40" fill="white" />
+    <circle cx="352" cy="400" r="40" fill="white" />
+    <path d="M188 272h136" />
+    <path d="M168 224h176" />
+    <path d="M212 176h96" />
+  </g>
+</svg>

--- a/frontend/public/icons/app-icon.svg
+++ b/frontend/public/icons/app-icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#grad)" />
+  <g fill="white" stroke="white" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M128 304h256c35.3 0 64 28.7 64 64v32c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32v-32c0-35.3 28.7-64 64-64z" fill-opacity="0.25" />
+    <path d="M160 320l40-120c9-26.8 34.2-44.8 62.5-44.8h47c28.3 0 53.5 18 62.5 44.8L412 320H160z" fill="none" />
+    <circle cx="196" cy="392" r="36" fill="white" />
+    <circle cx="356" cy="392" r="36" fill="white" />
+    <path d="M188 272h136" />
+    <path d="M172 224h168" />
+    <path d="M208 176h96" />
+  </g>
+</svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,38 @@
+{
+  "name": "Office Vehicle Booking System",
+  "short_name": "OVBS",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "description": "บริหารจัดการการจองรถสำนักงานและการอนุมัติผ่านมือถือได้ทุกที่",
+  "icons": [
+    {
+      "src": "/icons/app-icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    },
+    {
+      "src": "/icons/app-icon-maskable.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "สร้างคำขอจองรถ",
+      "short_name": "จองรถ",
+      "description": "เริ่มสร้างคำขอการใช้รถสำนักงาน",
+      "url": "/bookings/new"
+    },
+    {
+      "name": "ดูการแจ้งเตือน",
+      "short_name": "แจ้งเตือน",
+      "description": "ตรวจสอบการอนุมัติล่าสุด",
+      "url": "/notifications"
+    }
+  ]
+}

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="th">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>โหมดออฟไลน์ - ระบบจองรถสำนักงาน</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" />
+    <style>
+      body {
+        margin: 0;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        min-height: 100vh;
+        background: linear-gradient(135deg, #eff6ff 0%, #e0f2fe 100%);
+        color: #0f172a;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+      }
+      .card {
+        max-width: 420px;
+        width: 100%;
+        background: white;
+        border-radius: 1.5rem;
+        padding: 2.5rem;
+        box-shadow: 0 25px 50px -12px rgba(30, 64, 175, 0.25);
+        text-align: center;
+      }
+      h1 {
+        font-size: 1.75rem;
+        margin-bottom: 1rem;
+      }
+      p {
+        color: #475569;
+        line-height: 1.6;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #2563eb;
+        background: #eff6ff;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        margin-bottom: 1.5rem;
+      }
+      .actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-top: 2rem;
+      }
+      .btn-primary {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.85rem 1rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, #2563eb 0%, #0ea5e9 100%);
+        color: white;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .btn-secondary {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.85rem 1rem;
+        border-radius: 999px;
+        border: 1px solid #bfdbfe;
+        color: #1d4ed8;
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <div class="badge">🚗 พร้อมใช้งานแม้ออฟไลน์</div>
+      <h1>คุณอยู่ในโหมดออฟไลน์</h1>
+      <p>
+        ไม่ต้องกังวล! ระบบจะบันทึกการทำงานของคุณ และจะซิงค์ข้อมูลให้อัตโนมัติเมื่อกลับมาเชื่อมต่ออินเทอร์เน็ต
+      </p>
+      <div class="actions">
+        <a class="btn-primary" href="/">กลับไปที่หน้าหลัก</a>
+        <a class="btn-secondary" href="mailto:support@example.com">ติดต่อผู้ดูแลระบบ</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,229 @@
+/* eslint-disable no-restricted-globals */
+const APP_VERSION = 'v1.0.0';
+const STATIC_CACHE = `ovbs-static-${APP_VERSION}`;
+const API_CACHE = `ovbs-api-${APP_VERSION}`;
+const OFFLINE_URL = '/offline.html';
+const SYNC_TAG = 'ovbs-sync';
+const STATIC_ASSETS = [
+  '/',
+  OFFLINE_URL,
+  '/manifest.json',
+  '/icons/app-icon.svg',
+  '/icons/app-icon-maskable.svg',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.addAll(STATIC_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== STATIC_CACHE && key !== API_CACHE)
+            .map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+function cacheFirst(request) {
+  return caches.match(request).then((cached) => {
+    if (cached) {
+      return cached;
+    }
+    return fetch(request)
+      .then((response) => {
+        if (!response || response.status !== 200 || response.type !== 'basic') {
+          return response;
+        }
+        const cloned = response.clone();
+        caches.open(STATIC_CACHE).then((cache) => cache.put(request, cloned));
+        return response;
+      })
+      .catch(() => caches.match(OFFLINE_URL));
+  });
+}
+
+function networkFirst(request) {
+  return fetch(request)
+    .then((response) => {
+      if (response && response.status === 200) {
+        const cloned = response.clone();
+        caches.open(API_CACHE).then((cache) => cache.put(request, cloned));
+      }
+      return response;
+    })
+    .catch(() => caches.match(request).then((cached) => cached || caches.match(OFFLINE_URL)));
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  if (url.origin === self.location.origin) {
+    if (STATIC_ASSETS.includes(url.pathname) || url.pathname.startsWith('/_next/')) {
+      event.respondWith(cacheFirst(request));
+      return;
+    }
+  }
+
+  if (request.headers.get('accept')?.includes('text/html')) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const cloned = response.clone();
+          caches.open(STATIC_CACHE).then((cache) => cache.put(request, cloned));
+          return response;
+        })
+        .catch(() => caches.match(request).then((cached) => cached || caches.match(OFFLINE_URL)))
+    );
+    return;
+  }
+
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  event.respondWith(cacheFirst(request));
+});
+
+function openQueueDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('ovbs-offline', 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains('request-queue')) {
+        db.createObjectStore('request-queue', { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function enqueueRequest(payload) {
+  const db = await openQueueDb();
+  const tx = db.transaction('request-queue', 'readwrite');
+  tx.objectStore('request-queue').add({
+    createdAt: Date.now(),
+    ...payload,
+  });
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(true);
+    tx.onabort = () => reject(tx.error);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function processQueue() {
+  const db = await openQueueDb();
+  const tx = db.transaction('request-queue', 'readwrite');
+  const store = tx.objectStore('request-queue');
+  const items = await new Promise((resolve, reject) => {
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+  for (const item of items) {
+    try {
+      const { url, options } = item;
+      await fetch(url, options);
+      await new Promise((resolve, reject) => {
+        const deleteRequest = store.delete(item.id);
+        deleteRequest.onsuccess = () => resolve(true);
+        deleteRequest.onerror = () => reject(deleteRequest.error);
+      });
+    } catch (error) {
+      console.error('Failed to replay request', error);
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(true);
+    tx.onabort = () => reject(tx.error);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+self.addEventListener('message', (event) => {
+  const data = event.data || {};
+  if (data.type === 'QUEUE_REQUEST') {
+    event.waitUntil(
+      enqueueRequest(data.payload).then(() => self.registration.sync.register(SYNC_TAG))
+    );
+  }
+});
+
+self.addEventListener('sync', (event) => {
+  if (event.tag === SYNC_TAG) {
+    event.waitUntil(processQueue());
+  }
+});
+
+self.addEventListener('push', (event) => {
+  let payload = {};
+  try {
+    payload = event.data?.json() ?? {};
+  } catch (error) {
+    payload = { title: 'การแจ้งเตือนใหม่', body: event.data?.text() };
+  }
+
+  const title = payload.title || 'ระบบจองรถสำนักงาน';
+  const body = payload.body || 'คุณมีการอัปเดตใหม่ในคำขอจองรถของคุณ';
+
+  const options = {
+    body,
+    icon: '/icons/app-icon-maskable.svg',
+    badge: '/icons/app-icon.svg',
+    data: payload.data || {},
+    vibrate: [100, 50, 100],
+    actions: [
+      { action: 'open', title: 'เปิดรายละเอียด' },
+      { action: 'dismiss', title: 'ปิด' },
+    ],
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const action = event.action;
+  if (action === 'dismiss') {
+    return;
+  }
+
+  const targetUrl = event.notification.data?.url || '/notifications';
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if ('focus' in client) {
+            client.navigate(targetUrl);
+            return client.focus();
+          }
+        }
+        if (clients.openWindow) {
+          return clients.openWindow(targetUrl);
+        }
+        return null;
+      })
+  );
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,82 +2,140 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
+import { AppShell } from '@/components/layout/AppShell';
+import { MobileNotificationDrawer } from '@/components/layout/MobileNotificationDrawer';
 import { NotificationCenter } from '@/components/notifications/NotificationCenter';
+import { useNotificationCenter } from '@/components/notifications/useNotificationCenter';
 import { useAuth } from '@/context/AuthContext';
 
 export default function HomePage() {
   const router = useRouter();
   const { isAuthenticated, user, logout } = useAuth();
+  const notificationController = useNotificationCenter();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const handleLogout = () => {
     logout();
     router.push('/');
   };
 
-  if (!isAuthenticated) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50">
-        <div className="container mx-auto px-4 py-16">
-          <div className="grid gap-8 lg:grid-cols-[2fr_3fr]">
-            <div className="space-y-6">
-              <div className="rounded-2xl bg-white p-8 shadow-lg">
-                <h1 className="text-4xl font-bold text-gray-900">ระบบจองรถสำนักงาน</h1>
-                <p className="mt-3 text-xl text-gray-600">Office Vehicle Booking System</p>
-                <p className="mt-4 text-sm text-gray-500">
-                  แพลตฟอร์มบริหารจัดการการขอใช้รถสำหรับองค์กร พร้อมระบบอนุมัติหลายขั้นตอน การติดตามสถานะ และการแจ้งเตือนหลากหลายช่องทาง
-                </p>
+  const guestContent = (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-3xl bg-white p-6 shadow-xl shadow-primary-100/60 sm:p-10">
+        <div className="flex flex-col gap-4">
+          <span className="inline-flex max-w-max items-center gap-2 rounded-full bg-primary-100 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-primary-700">
+            จองรถง่ายในคลิกเดียว
+          </span>
+          <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">
+            ระบบจองรถสำนักงานพร้อมสำหรับการใช้งานบนมือถือของคุณ
+          </h1>
+          <p className="text-base leading-relaxed text-slate-600">
+            จัดการคำขอ ใช้กระบวนการอนุมัติหลายขั้นตอน และตรวจสอบสถานะได้ทุกที่ รองรับการใช้งานออฟไลน์และแจ้งเตือนแบบพุชทันทีเมื่อมีการอัปเดต
+          </p>
+        </div>
+        <div className="mt-8 grid gap-3 sm:grid-cols-2">
+          <Link href="/login" className="inline-flex items-center justify-center rounded-full bg-primary-600 px-6 py-4 text-base font-semibold text-white shadow-lg shadow-primary-300 transition hover:bg-primary-700">
+            เข้าสู่ระบบเพื่อเริ่มจองรถ
+          </Link>
+          <Link href="/register" className="inline-flex items-center justify-center rounded-full border border-primary-200 px-6 py-4 text-base font-semibold text-primary-600 transition hover:bg-primary-50">
+            สมัครใช้งานระบบ
+          </Link>
+        </div>
+      </section>
 
-                <div className="mt-6 grid gap-3 sm:grid-cols-2">
-                  <Link href="/login" className="btn-primary py-3 text-center">
-                    เข้าสู่ระบบ
-                  </Link>
-                  <Link href="/register" className="btn-secondary py-3 text-center">
-                    ลงทะเบียนใช้งาน
-                  </Link>
-                </div>
-              </div>
-            </div>
+      <section className="grid gap-4 sm:grid-cols-2">
+        {[
+          {
+            title: 'สร้างคำขอได้รวดเร็ว',
+            description: 'แบบฟอร์มอัจฉริยะช่วยกรอกข้อมูลเดิมและลดการพิมพ์ซ้ำ พร้อมตรวจสอบความพร้อมของรถโดยอัตโนมัติ',
+          },
+          {
+            title: 'ติดตามสถานะแบบเรียลไทม์',
+            description: 'รู้ทันทีเมื่อผู้จัดการอนุมัติหรือปฏิเสธ พร้อมประวัติคำขอที่เข้าถึงได้ทุกที่',
+          },
+          {
+            title: 'รองรับการใช้งานออฟไลน์',
+            description: 'บันทึกคำขอไว้ล่วงหน้าแม้ไม่มีอินเทอร์เน็ต ระบบจะส่งให้อัตโนมัติเมื่อกลับมาออนไลน์',
+          },
+          {
+            title: 'ปลอดภัยสำหรับองค์กร',
+            description: 'ข้อมูลทุกคำขอถูกเข้ารหัส พร้อมระบบสิทธิ์การใช้งานตามบทบาทและบันทึกการเปลี่ยนแปลง',
+          },
+        ].map((feature) => (
+          <article key={feature.title} className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
+            <h3 className="text-lg font-semibold text-slate-900">{feature.title}</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">{feature.description}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
 
-            <NotificationCenter />
+  const authenticatedContent = (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+      <section className="flex flex-col gap-6">
+        <div className="rounded-3xl bg-white p-6 shadow-xl shadow-primary-100/60 sm:p-10">
+          <div className="flex flex-col gap-4">
+            <span className="inline-flex max-w-max items-center gap-2 rounded-full bg-emerald-100 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+              พร้อมใช้งาน
+            </span>
+            <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">ยินดีต้อนรับกลับ {user?.fullName}</h1>
+            <p className="text-sm font-medium text-primary-600">
+              บทบาทของคุณ: <span className="font-semibold text-primary-700">{user?.role}</span>
+            </p>
+            <p className="text-base leading-relaxed text-slate-600">
+              ติดตามคำขอที่รอดำเนินการ ตรวจสอบตารางการใช้รถล่วงหน้า และรับการแจ้งเตือนอัตโนมัติแม้ออฟไลน์
+            </p>
+          </div>
+          <div className="mt-8 grid gap-3 sm:grid-cols-3">
+            <Link href="/bookings/new" className="flex flex-col items-center gap-2 rounded-2xl bg-primary-600 px-4 py-5 text-center text-sm font-semibold text-white shadow-lg shadow-primary-300 transition hover:bg-primary-700">
+              <span className="text-lg">➕</span>
+              สร้างคำขอใหม่
+            </Link>
+            <Link href="/calendar" className="flex flex-col items-center gap-2 rounded-2xl border border-primary-200 bg-primary-50 px-4 py-5 text-center text-sm font-semibold text-primary-600 transition hover:bg-primary-100">
+              <span className="text-lg">📅</span>
+              ปฏิทินการใช้รถ
+            </Link>
+            <Link href="/profile" className="flex flex-col items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-5 text-center text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+              <span className="text-lg">👤</span>
+              จัดการโปรไฟล์
+            </Link>
           </div>
         </div>
-      </div>
-    );
-  }
+
+        <div className="rounded-3xl border border-slate-100 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="text-lg font-semibold text-slate-900">สิ่งที่ต้องทำต่อไป</h2>
+          <ul className="mt-4 space-y-4 text-sm text-slate-600">
+            <li className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">ตรวจสอบคำขอที่รออนุมัติจากทีมงาน</li>
+            <li className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">บันทึกแผนการใช้รถสำหรับสัปดาห์หน้า</li>
+            <li className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">อัปเดตข้อมูลโปรไฟล์สำหรับการติดต่อฉุกเฉิน</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="hidden lg:block">
+        <NotificationCenter controller={notificationController} />
+      </section>
+    </div>
+  );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-50 to-secondary-50">
-      <div className="container mx-auto px-4 py-16">
-        <div className="grid gap-8 lg:grid-cols-[2fr_3fr]">
-          <div className="space-y-6">
-            <div className="rounded-2xl bg-white p-8 shadow-lg">
-              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <p className="text-sm uppercase tracking-wide text-primary-500">พร้อมใช้งาน</p>
-                  <h1 className="mt-1 text-3xl font-bold text-gray-900">ยินดีต้อนรับกลับ {user?.fullName}</h1>
-                  <p className="mt-2 text-sm text-gray-500">
-                    บทบาทของคุณ: <span className="font-semibold text-gray-700">{user?.role}</span>
-                  </p>
-                </div>
-                <div className="flex gap-3">
-                  <Link href="/profile" className="btn-secondary whitespace-nowrap px-4 py-2">
-                    จัดการโปรไฟล์
-                  </Link>
-                  <button type="button" onClick={handleLogout} className="btn-outline whitespace-nowrap px-4 py-2">
-                    ออกจากระบบ
-                  </button>
-                </div>
-              </div>
-              <p className="mt-6 text-sm text-gray-600">
-                ตรวจสอบการแจ้งเตือนล่าสุดและติดตามสถานะคำขอจองรถของคุณได้ทันที ระบบจะต่ออายุการเข้าสู่ระบบให้อัตโนมัติเมื่อโทเคนใกล้หมดอายุเพื่อให้คุณใช้งานได้อย่างต่อเนื่อง
-              </p>
-            </div>
-          </div>
+    <>
+      <AppShell
+        isAuthenticated={isAuthenticated}
+        fullName={user?.fullName}
+        unreadCount={notificationController.unreadCount}
+        onOpenNotifications={() => setDrawerOpen(true)}
+        onLogout={handleLogout}
+      >
+        {isAuthenticated ? authenticatedContent : guestContent}
+      </AppShell>
 
-          <NotificationCenter />
-        </div>
-      </div>
-    </div>
+      <MobileNotificationDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)}>
+        <NotificationCenter controller={notificationController} />
+      </MobileNotificationDrawer>
+    </>
   );
 }

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,9 +1,25 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { AuthProvider } from '@/context/AuthContext';
+import { registerServiceWorker } from '@/lib/pwa/client';
+
+function ServiceWorkerManager() {
+  useEffect(() => {
+    void registerServiceWorker();
+  }, []);
+
+  return null;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <AuthProvider>{children}</AuthProvider>;
+  return (
+    <AuthProvider>
+      <ServiceWorkerManager />
+      {children}
+    </AuthProvider>
+  );
 }
 
 export default Providers;

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { BellRing, Home, LogIn, Menu, User } from 'lucide-react';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+
+interface AppShellProps {
+  isAuthenticated: boolean;
+  fullName?: string;
+  unreadCount?: number;
+  onOpenNotifications?: () => void;
+  onLogout?: () => void;
+  children: React.ReactNode;
+}
+
+export function AppShell({
+  isAuthenticated,
+  fullName,
+  unreadCount = 0,
+  onOpenNotifications,
+  onLogout,
+  children,
+}: AppShellProps) {
+  const isOnline = useOnlineStatus();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const firstName = useMemo(() => fullName?.split(' ')[0] ?? '', [fullName]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gradient-to-br from-primary-50 via-white to-secondary-50">
+      <header className="sticky top-0 z-20 border-b border-white/50 bg-white/80 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-3">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-primary-100 bg-white text-primary-600 shadow-sm sm:hidden"
+              onClick={() => setMenuOpen((value) => !value)}
+            >
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">เปิดเมนู</span>
+            </button>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-primary-500">Office Vehicle</p>
+              <p className="text-lg font-bold text-slate-900">Booking System</p>
+              {isAuthenticated && firstName && (
+                <p className="text-xs text-slate-500">ยินดีต้อนรับกลับ {firstName}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {isAuthenticated ? (
+              <button
+                type="button"
+                onClick={onOpenNotifications}
+                className="relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary-100 bg-white text-primary-600 shadow"
+              >
+                <BellRing className="h-5 w-5" />
+                {unreadCount > 0 && (
+                  <span className="absolute -right-1 -top-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-white">
+                    {unreadCount}
+                  </span>
+                )}
+                <span className="sr-only">เปิดการแจ้งเตือน</span>
+              </button>
+            ) : (
+              <Link
+                href="/login"
+                className="inline-flex h-11 items-center gap-2 rounded-full border border-primary-100 bg-white px-4 text-sm font-semibold text-primary-600 shadow"
+              >
+                <LogIn className="h-4 w-4" />
+                เข้าสู่ระบบ
+              </Link>
+            )}
+
+            {isAuthenticated && (
+              <button
+                type="button"
+                onClick={onLogout}
+                className="hidden rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-50 sm:inline-flex"
+              >
+                ออกจากระบบ
+              </button>
+            )}
+          </div>
+        </div>
+
+        {menuOpen && (
+          <nav className="border-t border-primary-100 bg-white/95 px-4 py-3 sm:hidden">
+            <ul className="flex flex-col gap-2 text-sm text-slate-600">
+              <li>
+                <Link href="/" className="inline-flex w-full items-center gap-3 rounded-xl bg-primary-50 px-4 py-3 font-semibold text-primary-600">
+                  <Home className="h-4 w-4" /> หน้าหลัก
+                </Link>
+              </li>
+              {isAuthenticated ? (
+                <>
+                  <li>
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left"
+                      onClick={() => {
+                        onOpenNotifications?.();
+                        setMenuOpen(false);
+                      }}
+                    >
+                      <BellRing className="h-4 w-4" /> การแจ้งเตือน ({unreadCount})
+                    </button>
+                  </li>
+                  <li>
+                    <Link href="/profile" className="flex w-full items-center gap-3 rounded-xl px-4 py-3">
+                      <User className="h-4 w-4" /> โปรไฟล์ของฉัน
+                    </Link>
+                  </li>
+                  <li>
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onLogout?.();
+                      }}
+                    >
+                      <LogIn className="h-4 w-4 rotate-180" /> ออกจากระบบ
+                    </button>
+                  </li>
+                </>
+              ) : (
+                <li>
+                  <Link href="/register" className="flex w-full items-center gap-3 rounded-xl px-4 py-3">
+                    <User className="h-4 w-4" /> สมัครใช้งานระบบ
+                  </Link>
+                </li>
+              )}
+            </ul>
+          </nav>
+        )}
+
+        {!isOnline && (
+          <div className="border-t border-amber-200 bg-amber-50 px-4 py-2 text-xs font-medium text-amber-700">
+            โหมดออฟไลน์: ข้อมูลจะซิงค์ให้อัตโนมัติเมื่อกลับมาเชื่อมต่ออินเทอร์เน็ต
+          </div>
+        )}
+      </header>
+
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 pb-24 pt-8 sm:pb-12 sm:pt-12">
+        {children}
+      </main>
+
+      <footer className="fixed bottom-0 left-0 right-0 z-30 border-t border-white/60 bg-white/95 px-4 py-2 shadow-[0_-4px_30px_rgba(15,23,42,0.08)] backdrop-blur md:hidden">
+        <nav className="mx-auto flex w-full max-w-3xl items-center justify-between">
+          <Link href="/" className="flex flex-1 flex-col items-center gap-1 rounded-full px-3 py-2 text-xs font-semibold text-primary-600">
+            <Home className="h-5 w-5" /> หน้าหลัก
+          </Link>
+          {isAuthenticated ? (
+            <>
+              <button
+                type="button"
+                className="flex flex-1 flex-col items-center gap-1 rounded-full px-3 py-2 text-xs font-semibold text-slate-600"
+                onClick={onOpenNotifications}
+              >
+                <div className="relative">
+                  <BellRing className="h-5 w-5" />
+                  {unreadCount > 0 && (
+                    <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-white">
+                      {unreadCount}
+                    </span>
+                  )}
+                </div>
+                แจ้งเตือน
+              </button>
+              <Link
+                href="/profile"
+                className="flex flex-1 flex-col items-center gap-1 rounded-full px-3 py-2 text-xs font-semibold text-slate-600"
+              >
+                <User className="h-5 w-5" /> โปรไฟล์
+              </Link>
+            </>
+          ) : (
+            <Link
+              href="/register"
+              className="flex flex-1 flex-col items-center gap-1 rounded-full px-3 py-2 text-xs font-semibold text-slate-600"
+            >
+              <User className="h-5 w-5" /> สมัคร
+            </Link>
+          )}
+        </nav>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/MobileNotificationDrawer.tsx
+++ b/frontend/src/components/layout/MobileNotificationDrawer.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+
+interface MobileNotificationDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function MobileNotificationDrawer({ open, onClose, children }: MobileNotificationDrawerProps) {
+  const [dragOffset, setDragOffset] = useState(0);
+
+  useEffect(() => {
+    if (!open) {
+      setDragOffset(0);
+    }
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-slate-900/40 backdrop-blur-sm">
+      <div className="flex-1" onClick={onClose} role="presentation" />
+      <div
+        className="relative rounded-t-3xl bg-white shadow-2xl"
+        style={{ transform: `translateY(${dragOffset}px)` }}
+        onTouchStart={(event) => {
+          setDragOffset(0);
+          (event.target as HTMLElement).setAttribute('data-start-y', String(event.touches[0]?.clientY ?? 0));
+        }}
+        onTouchMove={(event) => {
+          const start = Number((event.target as HTMLElement).getAttribute('data-start-y') ?? 0);
+          const delta = (event.touches[0]?.clientY ?? start) - start;
+          if (delta > 0) {
+            setDragOffset(Math.min(delta, 280));
+          }
+        }}
+        onTouchEnd={() => {
+          if (dragOffset > 120) {
+            onClose();
+          }
+          setDragOffset(0);
+        }}
+      >
+        <div className="flex flex-col gap-4 px-6 pb-10 pt-5">
+          <div className="mx-auto h-1.5 w-16 rounded-full bg-slate-200" />
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -3,13 +3,20 @@
 import { FormEvent, useState } from 'react';
 
 import { useAuth } from '@/context/AuthContext';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 
 import { NotificationHistoryList } from './NotificationHistoryList';
 import { NotificationPreferencesForm } from './NotificationPreferencesForm';
-import { useNotificationCenter } from './useNotificationCenter';
+import { UseNotificationCenterResult, useNotificationCenter } from './useNotificationCenter';
 
-export function NotificationCenter() {
+interface NotificationCenterProps {
+  controller?: UseNotificationCenterResult;
+}
+
+export function NotificationCenter({ controller }: NotificationCenterProps) {
   const { isAuthenticated } = useAuth();
+  const isOnline = useOnlineStatus();
+  const fallbackController = useNotificationCenter();
   const {
     notifications,
     preferences,
@@ -21,12 +28,15 @@ export function NotificationCenter() {
     markAllRead,
     updatePreferences,
     sendTestNotification,
-  } = useNotificationCenter();
+    registerPushNotifications,
+  } = controller ?? fallbackController;
 
   const [testTitle, setTestTitle] = useState('ทดสอบระบบแจ้งเตือน');
   const [testMessage, setTestMessage] = useState('นี่คือข้อความตัวอย่างสำหรับตรวจสอบการตั้งค่า');
   const [sendingTest, setSendingTest] = useState(false);
   const [testStatus, setTestStatus] = useState<string | null>(null);
+  const [pushStatus, setPushStatus] = useState<string | null>(null);
+  const [enablingPush, setEnablingPush] = useState(false);
 
   if (!isAuthenticated) {
     return (
@@ -44,13 +54,31 @@ export function NotificationCenter() {
     setSendingTest(true);
     setTestStatus(null);
     try {
-      await sendTestNotification(testTitle, testMessage);
-      setTestStatus('ส่งข้อความทดสอบเรียบร้อยแล้ว');
+      const result = await sendTestNotification(testTitle, testMessage);
+      if (result === 'queued') {
+        setTestStatus('บันทึกคำขอเรียบร้อย ระบบจะส่งให้อัตโนมัติเมื่อกลับมาออนไลน์');
+      } else {
+        setTestStatus('ส่งข้อความทดสอบเรียบร้อยแล้ว');
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'ไม่สามารถส่งข้อความทดสอบ';
       setTestStatus(message);
     } finally {
       setSendingTest(false);
+    }
+  };
+
+  const handleEnablePush = async () => {
+    setEnablingPush(true);
+    setPushStatus(null);
+    try {
+      await registerPushNotifications();
+      setPushStatus('เปิดใช้งานการแจ้งเตือนผ่านเบราว์เซอร์เรียบร้อยแล้ว');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'ไม่สามารถเปิดใช้งานการแจ้งเตือนแบบพุช';
+      setPushStatus(message);
+    } finally {
+      setEnablingPush(false);
     }
   };
 
@@ -63,18 +91,43 @@ export function NotificationCenter() {
             จัดการการแจ้งเตือนหลายช่องทางและดูสถานะล่าสุดได้ในจุดเดียว
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          {!isOnline && (
+            <span className="rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">โหมดออฟไลน์</span>
+          )}
           <button
             type="button"
             onClick={() => {
               void refresh();
             }}
-            className="rounded-lg border border-primary-200 px-4 py-2 text-sm font-medium text-primary-600 hover:bg-primary-50"
+            className="rounded-full border border-primary-200 px-4 py-2 text-sm font-medium text-primary-600 transition hover:bg-primary-50"
           >
             รีเฟรชข้อมูล
           </button>
           {loading && <span className="text-sm text-gray-500">กำลังโหลด...</span>}
         </div>
+      </div>
+
+      <div className="rounded-xl border border-primary-100 bg-primary-50 px-4 py-3 text-sm text-primary-700 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-semibold">เปิดใช้งานการแจ้งเตือนผ่านเบราว์เซอร์</p>
+            <p className="text-xs text-primary-600">
+              ระบบจะส่งการแจ้งเตือนแบบพุชเมื่อมีการอนุมัติคำขอจองรถ แม้ปิดหน้าจอไว้
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              void handleEnablePush();
+            }}
+            disabled={enablingPush}
+            className="inline-flex items-center gap-2 rounded-full bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {enablingPush ? 'กำลังเปิดใช้งาน...' : 'เปิดใช้งานการแจ้งเตือน'}
+          </button>
+        </div>
+        {pushStatus && <p className="mt-2 text-xs text-primary-700">{pushStatus}</p>}
       </div>
 
       {error && (
@@ -89,11 +142,9 @@ export function NotificationCenter() {
         </div>
       )}
 
-      {preferences && (
-        <NotificationPreferencesForm preferences={preferences} onUpdate={updatePreferences} />
-      )}
+      {preferences && <NotificationPreferencesForm preferences={preferences} onUpdate={updatePreferences} />}
 
-      <form onSubmit={handleTestSubmit} className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <form onSubmit={handleTestSubmit} className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
         <h3 className="text-lg font-semibold text-gray-900">ส่งข้อความทดสอบ</h3>
         <p className="mt-1 text-sm text-gray-500">
           ใช้แบบฟอร์มนี้เพื่อตรวจสอบว่าการตั้งค่าการแจ้งเตือนและ LINE Notify ทำงานถูกต้อง
@@ -105,7 +156,7 @@ export function NotificationCenter() {
               type="text"
               value={testTitle}
               onChange={(event) => setTestTitle(event.target.value)}
-              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              className="rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
               disabled={sendingTest}
             />
           </div>
@@ -115,20 +166,25 @@ export function NotificationCenter() {
               value={testMessage}
               onChange={(event) => setTestMessage(event.target.value)}
               rows={3}
-              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              className="rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
               disabled={sendingTest}
             />
           </div>
         </div>
-        <div className="mt-4 flex items-center gap-3">
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
           <button
             type="submit"
-            className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center justify-center rounded-full bg-primary-500 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
             disabled={sendingTest}
           >
             ส่งข้อความทดสอบ
           </button>
           {testStatus && <span className="text-sm text-green-600">{testStatus}</span>}
+          {!isOnline && (
+            <span className="text-xs text-amber-600">
+              เราจะบันทึกคำขอนี้และส่งให้อัตโนมัติเมื่อกลับมาออนไลน์
+            </span>
+          )}
         </div>
       </form>
 
@@ -142,4 +198,3 @@ export function NotificationCenter() {
     </div>
   );
 }
-

--- a/frontend/src/components/notifications/NotificationHistoryList.tsx
+++ b/frontend/src/components/notifications/NotificationHistoryList.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo } from 'react';
 
+import { SwipeableListItem } from '@/components/ui/SwipeableListItem';
+
 import { NotificationItem } from './useNotificationCenter';
 
 interface NotificationHistoryListProps {
@@ -53,7 +55,7 @@ export function NotificationHistoryList({
         </div>
       </div>
 
-      <ul className="divide-y divide-gray-200">
+      <ul className="divide-y divide-gray-100">
         {sortedNotifications.length === 0 && (
           <li className="px-6 py-8 text-center text-sm text-gray-500">
             ยังไม่มีการแจ้งเตือนในระบบ ลองส่งข้อความทดสอบเพื่อเริ่มใช้งาน
@@ -66,49 +68,60 @@ export function NotificationHistoryList({
             : '-';
 
           return (
-            <li key={notification.id} className="flex flex-col gap-3 px-6 py-4 md:flex-row md:items-center md:justify-between">
-              <div>
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold uppercase tracking-wide text-primary-500">
-                    {notification.category}
-                  </span>
-                  {notification.deliveredChannels.map((channel) => (
-                    <span
-                      key={channel}
-                      className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
-                    >
-                      {channel.replace('_', ' ')}
-                    </span>
-                  ))}
+            <li key={notification.id} className="px-3 py-3 sm:px-6">
+              <SwipeableListItem
+                onSwipeLeft={() => {
+                  if (!notification.readAt) {
+                    void onMarkAsRead(notification.id).catch((err) => console.error(err));
+                  }
+                }}
+                actionContent={!notification.readAt ? 'อ่านแล้ว' : 'เสร็จสิ้น'}
+              >
+                <div className="flex flex-col gap-4 px-3 py-4 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-primary-500">
+                        {notification.category}
+                      </span>
+                      {notification.deliveredChannels.map((channel) => (
+                        <span
+                          key={channel}
+                          className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600"
+                        >
+                          {channel.replace('_', ' ')}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="mt-2 text-base font-semibold text-gray-900">{notification.title}</p>
+                    <p className="mt-2 text-sm leading-relaxed text-gray-600">{notification.message}</p>
+                    <p className="mt-3 text-xs text-gray-400">สร้างเมื่อ {createdLabel}</p>
+
+                    {Object.keys(notification.deliveryErrors ?? {}).length > 0 && (
+                      <p className="mt-2 text-xs text-red-500">
+                        ไม่สามารถส่งบางช่องทาง: {Object.values(notification.deliveryErrors).join(', ')}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex flex-row items-center gap-3 self-start md:flex-col md:items-end">
+                    {notification.readAt ? (
+                      <span className="rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-600">
+                        อ่านแล้ว
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void onMarkAsRead(notification.id).catch((err) => console.error(err));
+                        }}
+                        className="rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                      >
+                        แตะหรือปัดเพื่่ออ่านแล้ว
+                      </button>
+                    )}
+                  </div>
                 </div>
-                <p className="mt-1 text-base font-semibold text-gray-900">{notification.title}</p>
-                <p className="mt-1 text-sm text-gray-600">{notification.message}</p>
-                <p className="mt-2 text-xs text-gray-400">สร้างเมื่อ {createdLabel}</p>
-
-                {Object.keys(notification.deliveryErrors ?? {}).length > 0 && (
-                  <p className="mt-2 text-xs text-red-500">
-                    ไม่สามารถส่งบางช่องทาง: {Object.values(notification.deliveryErrors).join(', ')}
-                  </p>
-                )}
-              </div>
-
-              <div className="flex flex-row items-center gap-3 md:flex-col md:items-end">
-                {notification.readAt ? (
-                  <span className="rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-600">
-                    อ่านแล้ว
-                  </span>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void onMarkAsRead(notification.id).catch((err) => console.error(err));
-                    }}
-                    className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
-                  >
-                    ทำเครื่องหมายว่าอ่านแล้ว
-                  </button>
-                )}
-              </div>
+              </SwipeableListItem>
             </li>
           );
         })}

--- a/frontend/src/components/ui/SwipeableListItem.tsx
+++ b/frontend/src/components/ui/SwipeableListItem.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import clsx from 'clsx';
+import { ReactNode, useRef, useState } from 'react';
+
+interface SwipeableListItemProps {
+  onSwipeLeft?: () => void;
+  children: ReactNode;
+  actionContent?: ReactNode;
+}
+
+const MAX_SWIPE_DISTANCE = 140;
+const TRIGGER_DISTANCE = 90;
+
+export function SwipeableListItem({ onSwipeLeft, children, actionContent }: SwipeableListItemProps) {
+  const [translateX, setTranslateX] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const startX = useRef(0);
+  const animationFrame = useRef<number | null>(null);
+
+  const resetPosition = () => {
+    setTranslateX(0);
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    setIsDragging(true);
+    startX.current = event.clientX;
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) {
+      return;
+    }
+    const deltaX = event.clientX - startX.current;
+    if (deltaX > 0) {
+      setTranslateX(0);
+      return;
+    }
+
+    const nextTranslate = Math.max(deltaX, -MAX_SWIPE_DISTANCE);
+
+    if (animationFrame.current) {
+      cancelAnimationFrame(animationFrame.current);
+    }
+
+    animationFrame.current = requestAnimationFrame(() => {
+      setTranslateX(nextTranslate);
+    });
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) {
+      return;
+    }
+    setIsDragging(false);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+
+    if (Math.abs(translateX) >= TRIGGER_DISTANCE) {
+      onSwipeLeft?.();
+    }
+    resetPosition();
+  };
+
+  return (
+    <div className="relative touch-pan-y select-none">
+      <div className="absolute inset-y-0 right-0 flex items-center pr-4 text-sm text-white">
+        <div className="rounded-full bg-primary-500 px-4 py-2 shadow-lg">{actionContent}</div>
+      </div>
+      <div
+        role="button"
+        tabIndex={0}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onSwipeLeft?.();
+          }
+        }}
+        className={clsx(
+          'relative z-10 rounded-xl bg-white transition-transform duration-200 will-change-transform',
+          isDragging && 'cursor-grabbing'
+        )}
+        style={{ transform: `translateX(${translateX}px)` }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useOnlineStatus.ts
+++ b/frontend/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+    return window.navigator.onLine;
+  });
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/frontend/src/lib/pwa/client.ts
+++ b/frontend/src/lib/pwa/client.ts
@@ -1,0 +1,174 @@
+/* eslint-disable no-console */
+const SW_PATH = '/sw.js';
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined';
+}
+
+function base64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+
+  const rawData = window.atob(base64);
+  const buffer = new ArrayBuffer(rawData.length);
+  const outputArray = new Uint8Array(buffer);
+
+  for (let i = 0; i < rawData.length; i += 1) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!isBrowser() || !('serviceWorker' in navigator)) {
+    return null;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.register(SW_PATH, { scope: '/' });
+    await navigator.serviceWorker.ready;
+    return registration;
+  } catch (error) {
+    console.error('Failed to register service worker', error);
+    return null;
+  }
+}
+
+export async function getServiceWorkerRegistration(): Promise<ServiceWorkerRegistration | null> {
+  if (!isBrowser() || !('serviceWorker' in navigator)) {
+    return null;
+  }
+  const registration = await navigator.serviceWorker.ready.catch(() => null);
+  return registration ?? null;
+}
+
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (!isBrowser() || !('Notification' in window)) {
+    return 'denied';
+  }
+  if (Notification.permission === 'default') {
+    return Notification.requestPermission();
+  }
+  return Notification.permission;
+}
+
+export interface PushSubscriptionPayload {
+  subscription: PushSubscription;
+  endpoint: string;
+}
+
+export async function subscribeUserToPush(publicKey?: string): Promise<PushSubscriptionPayload | null> {
+  if (!isBrowser() || !('serviceWorker' in navigator) || !('PushManager' in window)) {
+    return null;
+  }
+
+  const registration = await getServiceWorkerRegistration();
+  if (!registration) {
+    return null;
+  }
+
+  const permission = await requestNotificationPermission();
+  if (permission !== 'granted') {
+    throw new Error('จำเป็นต้องเปิดสิทธิ์การแจ้งเตือนของเบราว์เซอร์');
+  }
+
+  const existingSubscription = await registration.pushManager.getSubscription();
+  if (existingSubscription) {
+    return { subscription: existingSubscription, endpoint: existingSubscription.endpoint };
+  }
+
+  if (!publicKey) {
+    throw new Error('ยังไม่ได้กำหนด public VAPID key สำหรับ Push Service');
+  }
+
+  const applicationServerKey = base64ToUint8Array(publicKey) as unknown as BufferSource;
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey,
+  });
+
+  return { subscription, endpoint: subscription.endpoint };
+}
+
+export interface QueueRequestPayload {
+  url: string;
+  options: RequestInit;
+}
+
+export async function queueBackgroundRequest(payload: QueueRequestPayload): Promise<void> {
+  if (!isBrowser() || !('serviceWorker' in navigator)) {
+    throw new Error('Service worker controller is not available');
+  }
+
+  const sendMessage = (target: ServiceWorker | null | undefined) => {
+    if (!target) {
+      throw new Error('Service worker controller is not available');
+    }
+    target.postMessage({
+      type: 'QUEUE_REQUEST',
+      payload,
+    });
+  };
+
+  if (navigator.serviceWorker.controller) {
+    sendMessage(navigator.serviceWorker.controller);
+    return;
+  }
+
+  const registration = await getServiceWorkerRegistration();
+  if (registration?.active) {
+    sendMessage(registration.active);
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const handleControllerChange = () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener('controllerchange', handleControllerChange);
+      if (navigator.serviceWorker.controller) {
+        sendMessage(navigator.serviceWorker.controller);
+        resolve();
+      } else {
+        reject(new Error('Service worker controller is not available'));
+      }
+    };
+
+    const timeout = window.setTimeout(() => {
+      window.removeEventListener('controllerchange', handleControllerChange);
+      reject(new Error('Service worker controller was not ready in time'));
+    }, 3000);
+
+    window.addEventListener('controllerchange', handleControllerChange);
+  });
+}
+
+export async function registerBackgroundSync(tag = 'ovbs-sync'): Promise<void> {
+  const registration = await getServiceWorkerRegistration();
+  if (!registration || !('sync' in registration)) {
+    return;
+  }
+  try {
+    const syncRegistration = registration as ServiceWorkerRegistration & {
+      sync: { register: (syncTag: string) => Promise<void> };
+    };
+    await syncRegistration.sync.register(tag);
+  } catch (error) {
+    console.error('Failed to register background sync', error);
+  }
+}
+
+export function onServiceWorkerMessage(callback: (data: unknown) => void): () => void {
+  if (!isBrowser() || !navigator.serviceWorker) {
+    return () => undefined;
+  }
+
+  const handler = (event: MessageEvent) => {
+    callback(event.data);
+  };
+
+  navigator.serviceWorker.addEventListener('message', handler);
+
+  return () => {
+    navigator.serviceWorker.removeEventListener('message', handler);
+  };
+}


### PR DESCRIPTION
## Summary
- implement a mobile-first home shell with responsive navigation, notification drawer, and swipe gestures for notification cards
- add service worker, offline fallback, and PWA manifest assets to enable offline-first behaviour and push notifications
- expose PWA utilities for registration, background sync, and push subscription while wiring them into notification features and global providers

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68ca6938d95883289740722c74c0e8ab