### PR TITLE
feat: add analytics reporting system

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -13,6 +13,7 @@ from app.api.api_v1.endpoints import (
     health,
     job_runs,
     notifications,
+    reports,
     uploads,
     users,
     vehicles,
@@ -38,3 +39,4 @@ api_router.include_router(
     notifications.router, prefix="/notifications", tags=["notifications"]
 )
 api_router.include_router(uploads.router, prefix="/uploads", tags=["uploads"])
+api_router.include_router(reports.router, prefix="/reports", tags=["reports"])

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -1,0 +1,237 @@
+"""Analytics and reporting API endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional, Sequence
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import RoleBasedAccess
+from app.db import get_async_session
+from app.models.user import User, UserRole
+from app.models.vehicle import VehicleType
+from app.schemas import (
+    BookingPatternReport,
+    CostOptimisationReport,
+    CustomReportDriverOption,
+    CustomReportOptionsRead,
+    CustomReportSummaryRead,
+    DepartmentUsageReport,
+    DriverPerformanceReport,
+    ExpenseAnalytics,
+    ExpenseStatusSummary,
+    PredictiveMaintenanceReport,
+    ReportOverviewResponse,
+    VehicleUtilisationReport,
+)
+from app.services.reports import (
+    BookingPatternInsight,
+    CostOptimisationRecommendation,
+    CustomReportOptions,
+    CustomReportSummary,
+    DepartmentUsageEntry,
+    DriverPerformanceEntry,
+    PredictiveMaintenanceInsight,
+    ReportOverview,
+    VehicleUtilisationEntry,
+    generate_report_overview,
+)
+
+router = APIRouter()
+
+_REPORT_ROLES = (UserRole.MANAGER, UserRole.FLEET_ADMIN, UserRole.AUDITOR)
+_require_reporting_access = RoleBasedAccess(_REPORT_ROLES)
+
+
+def _map_vehicle_utilisation(entries: Sequence[VehicleUtilisationEntry]) -> list[VehicleUtilisationReport]:
+    return [
+        VehicleUtilisationReport(
+            vehicle_id=item.vehicle_id,
+            registration_number=item.registration_number,
+            vehicle_type=item.vehicle_type,
+            total_trips=item.total_trips,
+            total_hours=item.total_hours,
+            active_days=item.active_days,
+            average_trip_duration_hours=item.average_trip_duration_hours,
+            utilisation_rate=item.utilisation_rate,
+            current_mileage=item.current_mileage,
+        )
+        for item in entries
+    ]
+
+
+def _map_department_usage(entries: Sequence[DepartmentUsageEntry]) -> list[DepartmentUsageReport]:
+    return [
+        DepartmentUsageReport(
+            period=item.period,
+            department=item.department,
+            total_requests=item.total_requests,
+            completed_trips=item.completed_trips,
+            total_passengers=item.total_passengers,
+            total_hours=item.total_hours,
+        )
+        for item in entries
+    ]
+
+
+def _map_driver_performance(entries: Sequence[DriverPerformanceEntry]) -> list[DriverPerformanceReport]:
+    return [
+        DriverPerformanceReport(
+            driver_id=item.driver_id,
+            full_name=item.full_name,
+            assignments=item.assignments,
+            completed_jobs=item.completed_jobs,
+            total_hours=item.total_hours,
+            average_completion_time_hours=item.average_completion_time_hours,
+            workload_index=item.workload_index,
+        )
+        for item in entries
+    ]
+
+
+def _map_booking_patterns(entries: Sequence[BookingPatternInsight]) -> list[BookingPatternReport]:
+    return [
+        BookingPatternReport(
+            day_of_week=item.day_of_week,
+            weekday_index=item.weekday_index,
+            average_bookings=item.average_bookings,
+            peak_hour=item.peak_hour,
+            average_passengers=item.average_passengers,
+        )
+        for item in entries
+    ]
+
+
+def _map_cost_recommendations(
+    entries: Sequence[CostOptimisationRecommendation],
+) -> list[CostOptimisationReport]:
+    return [
+        CostOptimisationReport(
+            label=item.label,
+            detail=item.detail,
+            potential_saving=item.potential_saving,
+        )
+        for item in entries
+    ]
+
+
+def _map_custom_summary(summary: CustomReportSummary) -> CustomReportSummaryRead:
+    return CustomReportSummaryRead(
+        total_bookings=summary.total_bookings,
+        total_completed=summary.total_completed,
+        total_expenses=summary.total_expenses,
+        average_booking_hours=summary.average_booking_hours,
+        filters=summary.filters,
+    )
+
+
+def _map_custom_options(options: CustomReportOptions) -> CustomReportOptionsRead:
+    return CustomReportOptionsRead(
+        departments=options.departments,
+        vehicle_types=options.vehicle_types,
+        drivers=[
+            CustomReportDriverOption(id=int(item["id"]), name=str(item["name"]))
+            for item in options.drivers
+        ],
+    )
+
+
+def _map_predictive(
+    predictive: Sequence[PredictiveMaintenanceInsight],
+) -> list[PredictiveMaintenanceReport]:
+    return [
+        PredictiveMaintenanceReport(
+            vehicle_id=item.vehicle_id,
+            registration_number=item.registration_number,
+            vehicle_type=item.vehicle_type,
+            risk_score=item.risk_score,
+            recommended_action=item.recommended_action,
+            projected_service_date=item.projected_service_date,
+        )
+        for item in predictive
+    ]
+
+
+def _map_expense_summary(report: ReportOverview) -> ExpenseAnalytics:
+    analytics = report.expense_summary
+    return ExpenseAnalytics(
+        generated_at=analytics.generated_at,
+        total_jobs=analytics.total_jobs,
+        total_fuel_cost=analytics.total_fuel_cost,
+        total_toll_cost=analytics.total_toll_cost,
+        total_other_expenses=analytics.total_other_expenses,
+        total_expenses=analytics.total_expenses,
+        average_fuel_cost=analytics.average_fuel_cost,
+        average_total_expense=analytics.average_total_expense,
+        status_breakdown=[
+            ExpenseStatusSummary(
+                status=entry.status,
+                count=entry.count,
+                total_expenses=entry.total_expenses,
+            )
+            for entry in analytics.status_breakdown
+        ],
+    )
+
+
+def _build_response(payload: ReportOverview) -> ReportOverviewResponse:
+    return ReportOverviewResponse(
+        generated_at=payload.generated_at,
+        timeframe_start=payload.timeframe_start,
+        timeframe_end=payload.timeframe_end,
+        vehicle_utilisation=_map_vehicle_utilisation(payload.vehicle_utilisation),
+        department_usage=_map_department_usage(payload.department_usage),
+        driver_performance=_map_driver_performance(payload.driver_performance),
+        expense_summary=_map_expense_summary(payload),
+        predictive_maintenance=_map_predictive(payload.predictive_maintenance),
+        booking_patterns=_map_booking_patterns(payload.booking_patterns),
+        cost_recommendations=_map_cost_recommendations(payload.cost_recommendations),
+        custom_report_summary=_map_custom_summary(payload.custom_report_summary),
+        custom_report_options=_map_custom_options(payload.custom_report_options),
+    )
+
+
+@router.get("/overview", response_model=ReportOverviewResponse)
+async def get_report_overview(
+    start: datetime | None = Query(default=None),
+    end: datetime | None = Query(default=None),
+    department: str | None = Query(default=None, min_length=1, max_length=100),
+    vehicle_type: VehicleType | None = Query(default=None),
+    drivers: list[int] | None = Query(default=None),
+    session: AsyncSession = Depends(get_async_session),
+    _: User = Depends(_require_reporting_access),
+) -> ReportOverviewResponse:
+    """Return the consolidated reporting overview for the selected filters."""
+
+    if start and end and start > end:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Start date must be before end date",
+        )
+
+    driver_ids: Optional[Sequence[int]] = drivers if drivers else None
+
+    report = await generate_report_overview(
+        session,
+        start=start,
+        end=end,
+        department=department,
+        vehicle_type=vehicle_type,
+        driver_ids=driver_ids,
+    )
+
+    return _build_response(report)
+
+
+@router.get("/health", response_model=dict[str, str])
+async def get_reporting_health(
+    _: User = Depends(_require_reporting_access),
+) -> dict[str, str]:
+    """Simple health endpoint to verify reporting access."""
+
+    return {"status": "ready"}
+
+
+__all__ = ["get_report_overview", "get_reporting_health", "router"]

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -72,6 +72,18 @@ from .notification import (
     NotificationPreferenceUpdate,
     NotificationRead,
 )
+from .report import (
+    BookingPatternReport,
+    CostOptimisationReport,
+    CustomReportDriverOption,
+    CustomReportOptionsRead,
+    CustomReportSummaryRead,
+    DepartmentUsageReport,
+    DriverPerformanceReport,
+    PredictiveMaintenanceReport,
+    ReportOverviewResponse,
+    VehicleUtilisationReport,
+)
 from .user import (
     UserCreate,
     UserPasswordChange,
@@ -156,6 +168,16 @@ __all__ = [
     "NotificationPreferenceRead",
     "NotificationPreferenceUpdate",
     "NotificationRead",
+    "BookingPatternReport",
+    "CostOptimisationReport",
+    "CustomReportDriverOption",
+    "CustomReportOptionsRead",
+    "CustomReportSummaryRead",
+    "DepartmentUsageReport",
+    "DriverPerformanceReport",
+    "PredictiveMaintenanceReport",
+    "ReportOverviewResponse",
+    "VehicleUtilisationReport",
     "SignedUrlResponse",
     "VehicleImageUploadResponse",
 ]

--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -1,0 +1,134 @@
+"""Pydantic models for reporting responses."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.models.vehicle import VehicleType
+from app.schemas.expense import ExpenseAnalytics
+
+
+class VehicleUtilisationReport(BaseModel):
+    """Vehicle utilisation metrics for reporting."""
+
+    vehicle_id: int
+    registration_number: str
+    vehicle_type: VehicleType
+    total_trips: int = Field(ge=0)
+    total_hours: float = Field(ge=0)
+    active_days: int = Field(ge=0)
+    average_trip_duration_hours: float = Field(ge=0)
+    utilisation_rate: float = Field(ge=0, le=100)
+    current_mileage: int = Field(ge=0)
+
+
+class DepartmentUsageReport(BaseModel):
+    """Monthly usage metrics grouped by department."""
+
+    period: date
+    department: str
+    total_requests: int = Field(ge=0)
+    completed_trips: int = Field(ge=0)
+    total_passengers: int = Field(ge=0)
+    total_hours: float = Field(ge=0)
+
+
+class DriverPerformanceReport(BaseModel):
+    """Driver workload and completion performance."""
+
+    driver_id: int
+    full_name: str
+    assignments: int = Field(ge=0)
+    completed_jobs: int = Field(ge=0)
+    total_hours: float = Field(ge=0)
+    average_completion_time_hours: float = Field(ge=0)
+    workload_index: float = Field(ge=0, le=100)
+
+
+class PredictiveMaintenanceReport(BaseModel):
+    """Predictive maintenance recommendation for a vehicle."""
+
+    vehicle_id: int
+    registration_number: str
+    vehicle_type: VehicleType
+    risk_score: float = Field(ge=0, le=100)
+    recommended_action: str
+    projected_service_date: date
+
+
+class BookingPatternReport(BaseModel):
+    """Booking pattern insight grouped by day of week."""
+
+    day_of_week: str
+    weekday_index: int = Field(ge=0, le=6)
+    average_bookings: float = Field(ge=0)
+    peak_hour: int = Field(ge=0, le=23)
+    average_passengers: float = Field(ge=0)
+
+
+class CostOptimisationReport(BaseModel):
+    """Cost optimisation recommendations."""
+
+    label: str
+    detail: str
+    potential_saving: float = Field(ge=0)
+
+
+class CustomReportDriverOption(BaseModel):
+    """Driver option for the custom report builder."""
+
+    id: int
+    name: str
+
+
+class CustomReportOptionsRead(BaseModel):
+    """Available filter options for the custom report builder."""
+
+    departments: list[str]
+    vehicle_types: list[VehicleType]
+    drivers: list[CustomReportDriverOption]
+
+
+class CustomReportSummaryRead(BaseModel):
+    """Summary payload for the custom report builder."""
+
+    total_bookings: int = Field(ge=0)
+    total_completed: int = Field(ge=0)
+    total_expenses: float = Field(ge=0)
+    average_booking_hours: float = Field(ge=0)
+    filters: dict[str, Any]
+
+
+class ReportOverviewResponse(BaseModel):
+    """Comprehensive reporting response."""
+
+    generated_at: datetime
+    timeframe_start: datetime | None
+    timeframe_end: datetime | None
+    vehicle_utilisation: list[VehicleUtilisationReport]
+    department_usage: list[DepartmentUsageReport]
+    driver_performance: list[DriverPerformanceReport]
+    expense_summary: ExpenseAnalytics
+    predictive_maintenance: list[PredictiveMaintenanceReport]
+    booking_patterns: list[BookingPatternReport]
+    cost_recommendations: list[CostOptimisationReport]
+    custom_report_summary: CustomReportSummaryRead
+    custom_report_options: CustomReportOptionsRead
+
+
+__all__ = [
+    "BookingPatternReport",
+    "CostOptimisationReport",
+    "CustomReportDriverOption",
+    "CustomReportOptionsRead",
+    "CustomReportSummaryRead",
+    "DepartmentUsageReport",
+    "DriverPerformanceReport",
+    "PredictiveMaintenanceReport",
+    "ReportOverviewResponse",
+    "VehicleUtilisationReport",
+]

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -1,0 +1,746 @@
+"""Reporting and analytics services for fleet operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Iterable, Optional, Sequence
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.assignment import Assignment
+from app.models.booking import BookingRequest, BookingStatus
+from app.models.driver import Driver
+from app.models.job_run import JobRun, JobRunStatus
+from app.models.vehicle import Vehicle, VehicleType
+from app.services.expense import ExpenseAnalyticsResult, generate_expense_analytics
+
+_UTILISATION_STATUSES: Sequence[BookingStatus] = (
+    BookingStatus.APPROVED,
+    BookingStatus.ASSIGNED,
+    BookingStatus.IN_PROGRESS,
+    BookingStatus.COMPLETED,
+)
+
+
+def _normalise_department(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _duration_hours_expression(model: BookingRequest) -> func:  # type: ignore[type-arg]
+    """Return an SQL expression that calculates booking duration in hours."""
+
+    seconds = func.coalesce(
+        func.extract("epoch", model.end_datetime - model.start_datetime),
+        0,
+    )
+    return seconds / 3600.0
+
+
+def _job_run_duration_expression() -> func:  # type: ignore[type-arg]
+    """Return an SQL expression that calculates actual trip duration in hours."""
+
+    seconds = func.coalesce(
+        func.extract("epoch", JobRun.checkout_datetime - JobRun.checkin_datetime),
+        0,
+    )
+    return seconds / 3600.0
+
+
+@dataclass(slots=True)
+class VehicleUtilisationEntry:
+    """Aggregated utilisation metrics for a vehicle."""
+
+    vehicle_id: int
+    registration_number: str
+    vehicle_type: VehicleType
+    total_trips: int
+    total_hours: float
+    active_days: int
+    average_trip_duration_hours: float
+    utilisation_rate: float
+    current_mileage: int
+
+
+@dataclass(slots=True)
+class DepartmentUsageEntry:
+    """Monthly usage metrics grouped by department."""
+
+    period: date
+    department: str
+    total_requests: int
+    completed_trips: int
+    total_passengers: int
+    total_hours: float
+
+
+@dataclass(slots=True)
+class DriverPerformanceEntry:
+    """Aggregated performance and workload metrics for drivers."""
+
+    driver_id: int
+    full_name: str
+    assignments: int
+    completed_jobs: int
+    total_hours: float
+    average_completion_time_hours: float
+    workload_index: float
+
+
+@dataclass(slots=True)
+class PredictiveMaintenanceInsight:
+    """Predictive maintenance signal for a vehicle."""
+
+    vehicle_id: int
+    registration_number: str
+    vehicle_type: VehicleType
+    risk_score: float
+    recommended_action: str
+    projected_service_date: date
+
+
+@dataclass(slots=True)
+class BookingPatternInsight:
+    """Booking distribution insight for a specific day of week."""
+
+    day_of_week: str
+    weekday_index: int
+    average_bookings: float
+    peak_hour: int
+    average_passengers: float
+
+
+@dataclass(slots=True)
+class CostOptimisationRecommendation:
+    """Cost optimisation suggestion based on expense trends."""
+
+    label: str
+    detail: str
+    potential_saving: float
+
+
+@dataclass(slots=True)
+class CustomReportSummary:
+    """Summary statistics for the custom report builder."""
+
+    total_bookings: int
+    total_completed: int
+    total_expenses: float
+    average_booking_hours: float
+    filters: dict[str, object]
+
+
+@dataclass(slots=True)
+class CustomReportOptions:
+    """Available filtering options for the custom report builder."""
+
+    departments: list[str]
+    vehicle_types: list[VehicleType]
+    drivers: list[dict[str, object]]
+
+
+@dataclass(slots=True)
+class ReportOverview:
+    """Comprehensive reporting payload."""
+
+    generated_at: datetime
+    timeframe_start: Optional[datetime]
+    timeframe_end: Optional[datetime]
+    vehicle_utilisation: list[VehicleUtilisationEntry]
+    department_usage: list[DepartmentUsageEntry]
+    driver_performance: list[DriverPerformanceEntry]
+    expense_summary: ExpenseAnalyticsResult
+    predictive_maintenance: list[PredictiveMaintenanceInsight]
+    booking_patterns: list[BookingPatternInsight]
+    cost_recommendations: list[CostOptimisationRecommendation]
+    custom_report_summary: CustomReportSummary
+    custom_report_options: CustomReportOptions
+
+
+async def _base_booking_filters(
+    start: Optional[datetime],
+    end: Optional[datetime],
+    department: Optional[str],
+) -> list:
+    filters: list = [BookingRequest.status.in_(_UTILISATION_STATUSES)]
+    if start is not None:
+        filters.append(BookingRequest.start_datetime >= start)
+    if end is not None:
+        filters.append(BookingRequest.end_datetime <= end)
+    if department is not None:
+        filters.append(func.lower(BookingRequest.department) == department.lower())
+    return filters
+
+
+async def _gather_vehicle_utilisation(
+    session: AsyncSession,
+    *,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    department: Optional[str],
+    vehicle_type: Optional[VehicleType],
+) -> list[VehicleUtilisationEntry]:
+    filters = await _base_booking_filters(start, end, department)
+
+    stmt = (
+        select(
+            Vehicle.id,
+            Vehicle.registration_number,
+            Vehicle.vehicle_type,
+            Vehicle.current_mileage,
+            func.count(BookingRequest.id),
+            func.coalesce(func.sum(_duration_hours_expression(BookingRequest)), 0.0),
+            func.count(
+                func.distinct(func.date_trunc("day", BookingRequest.start_datetime))
+            ),
+        )
+        .join(Assignment, Assignment.vehicle_id == Vehicle.id)
+        .join(BookingRequest, BookingRequest.id == Assignment.booking_request_id)
+        .where(*filters)
+        .group_by(Vehicle.id)
+        .order_by(func.count(BookingRequest.id).desc())
+    )
+
+    if vehicle_type is not None:
+        stmt = stmt.where(Vehicle.vehicle_type == vehicle_type)
+
+    rows = await session.execute(stmt)
+
+    entries: list[VehicleUtilisationEntry] = []
+    for row in rows.all():
+        (
+            vehicle_id,
+            registration_number,
+            vehicle_type_value,
+            current_mileage,
+            trip_count,
+            total_hours,
+            active_days,
+        ) = row
+
+        trips = int(trip_count or 0)
+        hours = float(total_hours or 0.0)
+        days = int(active_days or 0)
+        average_duration = hours / trips if trips else 0.0
+        capacity_hours = days * 24 if days else (24 if trips else 0)
+        utilisation_rate = (
+            (hours / capacity_hours) * 100 if capacity_hours else (100.0 if trips else 0.0)
+        )
+        utilisation_rate = float(max(0.0, min(utilisation_rate, 100.0)))
+        entries.append(
+            VehicleUtilisationEntry(
+                vehicle_id=int(vehicle_id),
+                registration_number=registration_number,
+                vehicle_type=vehicle_type_value,
+                total_trips=trips,
+                total_hours=round(hours, 2),
+                active_days=days,
+                average_trip_duration_hours=round(average_duration, 2),
+                utilisation_rate=round(utilisation_rate, 2),
+                current_mileage=int(current_mileage or 0),
+            )
+        )
+
+    return entries
+
+
+async def _gather_department_usage(
+    session: AsyncSession,
+    *,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    department: Optional[str],
+    vehicle_type: Optional[VehicleType],
+) -> list[DepartmentUsageEntry]:
+    filters = await _base_booking_filters(start, end, department)
+
+    stmt = (
+        select(
+            func.date_trunc("month", BookingRequest.start_datetime),
+            func.coalesce(BookingRequest.department, "ไม่ระบุ"),
+            func.count(BookingRequest.id),
+            func.sum(
+                case((JobRun.status == JobRunStatus.COMPLETED, 1), else_=0)
+            ),
+            func.coalesce(func.sum(BookingRequest.passenger_count), 0),
+            func.coalesce(func.sum(_duration_hours_expression(BookingRequest)), 0.0),
+        )
+        .join(Assignment, Assignment.booking_request_id == BookingRequest.id)
+        .join(Vehicle, Vehicle.id == Assignment.vehicle_id)
+        .outerjoin(JobRun, JobRun.booking_request_id == BookingRequest.id)
+        .where(*filters)
+        .group_by(func.date_trunc("month", BookingRequest.start_datetime), BookingRequest.department)
+        .order_by(func.date_trunc("month", BookingRequest.start_datetime))
+    )
+
+    if vehicle_type is not None:
+        stmt = stmt.where(Vehicle.vehicle_type == vehicle_type)
+
+    rows = await session.execute(stmt)
+
+    results: list[DepartmentUsageEntry] = []
+    for row in rows.all():
+        (
+            period,
+            department_value,
+            total_requests,
+            completed_trips,
+            passenger_total,
+            total_hours,
+        ) = row
+
+        month_date = (period or datetime.now(UTC)).date()
+        results.append(
+            DepartmentUsageEntry(
+                period=month_date.replace(day=1),
+                department=str(department_value or "ไม่ระบุ"),
+                total_requests=int(total_requests or 0),
+                completed_trips=int(completed_trips or 0),
+                total_passengers=int(passenger_total or 0),
+                total_hours=round(float(total_hours or 0.0), 2),
+            )
+        )
+
+    return results
+
+
+async def _gather_driver_performance(
+    session: AsyncSession,
+    *,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    department: Optional[str],
+    vehicle_type: Optional[VehicleType],
+) -> list[DriverPerformanceEntry]:
+    filters = await _base_booking_filters(start, end, department)
+
+    stmt = (
+        select(
+            Driver.id,
+            Driver.full_name,
+            func.count(Assignment.id),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (JobRun.status == JobRunStatus.COMPLETED, _job_run_duration_expression()),
+                        else_=0.0,
+                    )
+                ),
+                0.0,
+            ),
+            func.coalesce(
+                func.sum(case((JobRun.status == JobRunStatus.COMPLETED, 1), else_=0)),
+                0,
+            ),
+            func.coalesce(
+                func.avg(
+                    case(
+                        (JobRun.status == JobRunStatus.COMPLETED, _job_run_duration_expression()),
+                        else_=None,
+                    )
+                ),
+                0.0,
+            ),
+        )
+        .join(Assignment, Assignment.driver_id == Driver.id)
+        .join(BookingRequest, BookingRequest.id == Assignment.booking_request_id)
+        .outerjoin(JobRun, JobRun.booking_request_id == BookingRequest.id)
+        .join(Vehicle, Vehicle.id == Assignment.vehicle_id)
+        .where(*filters)
+        .group_by(Driver.id)
+        .order_by(func.count(Assignment.id).desc())
+    )
+
+    if vehicle_type is not None:
+        stmt = stmt.where(Vehicle.vehicle_type == vehicle_type)
+
+    rows = await session.execute(stmt)
+
+    entries: list[DriverPerformanceEntry] = []
+    for row in rows.all():
+        (
+            driver_id,
+            full_name,
+            assignment_count,
+            total_hours,
+            completed_jobs,
+            average_hours,
+        ) = row
+
+        assignments = int(assignment_count or 0)
+        completed = int(completed_jobs or 0)
+        total_duration = float(total_hours or 0.0)
+        average_duration = float(average_hours or 0.0)
+        workload = (
+            min(100.0, (completed / assignments) * 100) if assignments else 0.0
+        )
+        entries.append(
+            DriverPerformanceEntry(
+                driver_id=int(driver_id),
+                full_name=full_name,
+                assignments=assignments,
+                completed_jobs=completed,
+                total_hours=round(total_duration, 2),
+                average_completion_time_hours=round(average_duration, 2),
+                workload_index=round(workload, 2),
+            )
+        )
+
+    return entries
+
+
+async def _gather_booking_patterns(
+    session: AsyncSession,
+    *,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    department: Optional[str],
+) -> list[BookingPatternInsight]:
+    filters = await _base_booking_filters(start, end, department)
+
+    day_stmt = (
+        select(
+            func.extract("dow", BookingRequest.start_datetime),
+            func.coalesce(func.count(BookingRequest.id), 0),
+            func.coalesce(func.avg(BookingRequest.passenger_count), 0.0),
+        )
+        .where(*filters)
+        .group_by(func.extract("dow", BookingRequest.start_datetime))
+    )
+
+    hour_stmt = (
+        select(
+            func.extract("hour", BookingRequest.start_datetime),
+            func.count(BookingRequest.id),
+        )
+        .where(*filters)
+        .group_by(func.extract("hour", BookingRequest.start_datetime))
+    )
+
+    day_rows = await session.execute(day_stmt)
+    hour_rows = await session.execute(hour_stmt)
+
+    hourly_counts = {int(hour): int(count) for hour, count in hour_rows.all()}
+    peak_hour = max(hourly_counts, key=hourly_counts.get, default=8)
+
+    insights: list[BookingPatternInsight] = []
+    for weekday_index, booking_count, passengers in day_rows.all():
+        weekday = int(weekday_index or 0)
+        average_bookings = float(booking_count or 0) / max(1, len(hourly_counts) or 1)
+        average_passengers = float(passengers or 0.0)
+        day_label = [
+            "วันอาทิตย์",
+            "วันจันทร์",
+            "วันอังคาร",
+            "วันพุธ",
+            "วันพฤหัสบดี",
+            "วันศุกร์",
+            "วันเสาร์",
+        ][weekday % 7]
+        insights.append(
+            BookingPatternInsight(
+                day_of_week=day_label,
+                weekday_index=weekday,
+                average_bookings=round(average_bookings, 2),
+                peak_hour=int(peak_hour),
+                average_passengers=round(average_passengers, 2),
+            )
+        )
+
+    insights.sort(key=lambda item: item.weekday_index)
+    return insights
+
+
+async def _gather_cost_recommendations(
+    session: AsyncSession,
+    *,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    department: Optional[str],
+) -> list[CostOptimisationRecommendation]:
+    filters = await _base_booking_filters(start, end, department)
+    filters.append(JobRun.checkout_datetime.is_not(None))
+
+    expense_stmt = (
+        select(
+            func.coalesce(BookingRequest.department, "ไม่ระบุ"),
+            func.coalesce(
+                func.sum(
+                    JobRun.fuel_cost + JobRun.toll_cost + JobRun.other_expenses
+                ),
+                0,
+            ),
+            func.count(JobRun.id),
+        )
+        .join(JobRun, JobRun.booking_request_id == BookingRequest.id)
+        .where(*filters)
+        .group_by(BookingRequest.department)
+    )
+
+    rows = await session.execute(expense_stmt)
+
+    recommendations: list[CostOptimisationRecommendation] = []
+    for department_value, total_expense, job_count in rows.all():
+        trips = int(job_count or 0)
+        total = float(total_expense or 0.0)
+        if trips == 0:
+            continue
+        cost_per_trip = total / trips
+        potential = round(cost_per_trip * 0.1, 2)
+        recommendations.append(
+            CostOptimisationRecommendation(
+                label=f"{department_value or 'ไม่ระบุ'}",
+                detail=(
+                    "ค่าใช้จ่ายต่อการเดินทางสูงกว่าค่าเฉลี่ย เสนอให้ประเมินการใช้รถร่วม"
+                    if cost_per_trip > 1500
+                    else "พิจารณากำหนดเส้นทางให้มีการรวมงานเพื่อลดค่าใช้จ่าย"
+                ),
+                potential_saving=potential,
+            )
+        )
+
+    if not recommendations:
+        recommendations.append(
+            CostOptimisationRecommendation(
+                label="ภาพรวม",
+                detail="ค่าใช้จ่ายอยู่ในระดับที่ควบคุมได้ ควรรักษาการติดตามอย่างต่อเนื่อง",
+                potential_saving=0.0,
+            )
+        )
+
+    return recommendations
+
+
+async def _gather_custom_report_summary(
+    session: AsyncSession,
+    *,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    department: Optional[str],
+    vehicle_type: Optional[VehicleType],
+    driver_ids: Optional[Sequence[int]] = None,
+) -> CustomReportSummary:
+    filters = await _base_booking_filters(start, end, department)
+
+    stmt = (
+        select(
+            func.count(BookingRequest.id),
+            func.sum(
+                case((JobRun.status == JobRunStatus.COMPLETED, 1), else_=0)
+            ),
+            func.coalesce(func.sum(_duration_hours_expression(BookingRequest)), 0.0),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (JobRun.status.in_([JobRunStatus.COMPLETED, JobRunStatus.IN_PROGRESS]),
+                         JobRun.fuel_cost + JobRun.toll_cost + JobRun.other_expenses),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ),
+        )
+        .join(Assignment, Assignment.booking_request_id == BookingRequest.id)
+        .join(Vehicle, Vehicle.id == Assignment.vehicle_id)
+        .outerjoin(JobRun, JobRun.booking_request_id == BookingRequest.id)
+        .where(*filters)
+    )
+
+    if vehicle_type is not None:
+        stmt = stmt.where(Vehicle.vehicle_type == vehicle_type)
+    if driver_ids:
+        stmt = stmt.where(Assignment.driver_id.in_(driver_ids))
+
+    total_bookings, total_completed, total_hours, total_expenses = (
+        await session.execute(stmt)
+    ).one()
+
+    bookings = int(total_bookings or 0)
+    completed = int(total_completed or 0)
+    hours = float(total_hours or 0.0)
+    expenses = float(total_expenses or 0.0)
+    average_hours = hours / bookings if bookings else 0.0
+
+    filters_payload: dict[str, object] = {}
+    if start:
+        filters_payload["start"] = start.isoformat()
+    if end:
+        filters_payload["end"] = end.isoformat()
+    if department:
+        filters_payload["department"] = department
+    if vehicle_type is not None:
+        filters_payload["vehicle_type"] = vehicle_type.value
+    if driver_ids:
+        filters_payload["drivers"] = list(driver_ids)
+
+    return CustomReportSummary(
+        total_bookings=bookings,
+        total_completed=completed,
+        total_expenses=round(expenses, 2),
+        average_booking_hours=round(average_hours, 2),
+        filters=filters_payload,
+    )
+
+
+async def _gather_custom_report_options(session: AsyncSession) -> CustomReportOptions:
+    department_stmt = select(func.distinct(BookingRequest.department)).order_by(
+        BookingRequest.department
+    )
+    vehicle_stmt = select(func.distinct(Vehicle.vehicle_type)).order_by(Vehicle.vehicle_type)
+    driver_stmt = select(Driver.id, Driver.full_name).order_by(Driver.full_name)
+
+    departments = [
+        value
+        for (value,) in (await session.execute(department_stmt)).all()
+        if value
+    ]
+    vehicle_types = [
+        value
+        for (value,) in (await session.execute(vehicle_stmt)).all()
+        if value is not None
+    ]
+    drivers = [
+        {"id": int(driver_id), "name": full_name}
+        for driver_id, full_name in (await session.execute(driver_stmt)).all()
+    ]
+
+    return CustomReportOptions(
+        departments=departments,
+        vehicle_types=vehicle_types,
+        drivers=drivers,
+    )
+
+
+def _build_predictive_maintenance(
+    utilisation: Iterable[VehicleUtilisationEntry],
+) -> list[PredictiveMaintenanceInsight]:
+    today = datetime.now(UTC).date()
+    insights: list[PredictiveMaintenanceInsight] = []
+    for entry in utilisation:
+        mileage_factor = min(1.0, entry.current_mileage / 120_000)
+        utilisation_factor = entry.utilisation_rate / 100.0
+        duration_factor = min(1.0, entry.average_trip_duration_hours / 8.0)
+        risk = round((mileage_factor * 0.5 + utilisation_factor * 0.35 + duration_factor * 0.15) * 100, 2)
+        if risk >= 80:
+            recommendation = "ควรจัดตารางบำรุงรักษาภายใน 7 วัน"
+            offset = 7
+        elif risk >= 60:
+            recommendation = "ตรวจสอบระบบหลักและเตรียมอะไหล่สำรอง"
+            offset = 14
+        elif risk >= 40:
+            recommendation = "ติดตามข้อมูลการใช้งานอย่างใกล้ชิด"
+            offset = 21
+        else:
+            recommendation = "อยู่ในสภาพพร้อมใช้งาน ตรวจสอบตามรอบปกติ"
+            offset = 30
+
+        insights.append(
+            PredictiveMaintenanceInsight(
+                vehicle_id=entry.vehicle_id,
+                registration_number=entry.registration_number,
+                vehicle_type=entry.vehicle_type,
+                risk_score=risk,
+                recommended_action=recommendation,
+                projected_service_date=today.replace(day=min(today.day + offset, 28)),
+            )
+        )
+
+    return insights
+
+
+async def generate_report_overview(
+    session: AsyncSession,
+    *,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    department: Optional[str] = None,
+    vehicle_type: Optional[VehicleType] = None,
+    driver_ids: Optional[Sequence[int]] = None,
+) -> ReportOverview:
+    """Generate an aggregated reporting overview for the requested filters."""
+
+    department_filter = _normalise_department(department)
+
+    vehicle_utilisation = await _gather_vehicle_utilisation(
+        session,
+        start=start,
+        end=end,
+        department=department_filter,
+        vehicle_type=vehicle_type,
+    )
+    department_usage = await _gather_department_usage(
+        session,
+        start=start,
+        end=end,
+        department=department_filter,
+        vehicle_type=vehicle_type,
+    )
+    driver_performance = await _gather_driver_performance(
+        session,
+        start=start,
+        end=end,
+        department=department_filter,
+        vehicle_type=vehicle_type,
+    )
+    expense_summary = await generate_expense_analytics(
+        session,
+        start=start,
+        end=end,
+        status=None,
+    )
+    booking_patterns = await _gather_booking_patterns(
+        session,
+        start=start,
+        end=end,
+        department=department_filter,
+    )
+    cost_recommendations = await _gather_cost_recommendations(
+        session,
+        start=start,
+        end=end,
+        department=department_filter,
+    )
+    custom_report_summary = await _gather_custom_report_summary(
+        session,
+        start=start,
+        end=end,
+        department=department_filter,
+        vehicle_type=vehicle_type,
+        driver_ids=driver_ids,
+    )
+    custom_report_options = await _gather_custom_report_options(session)
+    predictive_maintenance = _build_predictive_maintenance(vehicle_utilisation)
+
+    return ReportOverview(
+        generated_at=datetime.now(UTC),
+        timeframe_start=start,
+        timeframe_end=end,
+        vehicle_utilisation=vehicle_utilisation,
+        department_usage=department_usage,
+        driver_performance=driver_performance,
+        expense_summary=expense_summary,
+        predictive_maintenance=predictive_maintenance,
+        booking_patterns=booking_patterns,
+        cost_recommendations=cost_recommendations,
+        custom_report_summary=custom_report_summary,
+        custom_report_options=custom_report_options,
+    )
+
+
+__all__ = [
+    "BookingPatternInsight",
+    "CostOptimisationRecommendation",
+    "CustomReportOptions",
+    "CustomReportSummary",
+    "DepartmentUsageEntry",
+    "DriverPerformanceEntry",
+    "PredictiveMaintenanceInsight",
+    "ReportOverview",
+    "VehicleUtilisationEntry",
+    "generate_report_overview",
+]

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -1,0 +1,732 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  Activity,
+  BarChart3,
+  CalendarClock,
+  Factory,
+  Filter,
+  Fuel,
+  Gauge,
+  LineChart,
+  RefreshCcw,
+  Sparkles,
+  TrendingUp,
+  Users2,
+} from 'lucide-react';
+
+import {
+  HorizontalBarChart,
+  SimpleColumnChart,
+  StackedProgressBar,
+  TrendPill,
+} from '@/components/reports/visuals';
+import type {
+  BookingPattern,
+  CostRecommendation,
+  CustomReportOptions,
+  CustomReportSummary,
+  DepartmentUsage,
+  DriverPerformance,
+  ExpenseAnalytics,
+  PredictiveMaintenance,
+  RawReportOverview,
+  ReportOverview,
+  VehicleUtilisation,
+} from '@/components/reports/types';
+import {
+  CardGrid,
+  SectionCard,
+  StatCard,
+} from '@/components/dashboard/shared';
+import { useAuth } from '@/context/AuthContext';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+interface ReportFilters {
+  start: string;
+  end: string;
+  department: string;
+  vehicleType: string;
+  drivers: number[];
+}
+
+const initialFilters: ReportFilters = {
+  start: '',
+  end: '',
+  department: '',
+  vehicleType: '',
+  drivers: [],
+};
+
+function parseNumber(value: number | string): number {
+  if (typeof value === 'number') return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString('th-TH', { style: 'currency', currency: 'THB' });
+}
+
+function toIsoBoundary(value: string, endOfDay = false): string {
+  if (!value) return '';
+  const [year, month, day] = value.split('-').map((segment) => Number(segment));
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return '';
+  }
+  const date = new Date(Date.UTC(year, month - 1, day, endOfDay ? 23 : 0, endOfDay ? 59 : 0, endOfDay ? 59 : 0));
+  return date.toISOString();
+}
+
+function normaliseReport(payload: RawReportOverview): ReportOverview {
+  const vehicleUtilisation: VehicleUtilisation[] = payload.vehicle_utilisation.map((item) => ({
+    ...item,
+  }));
+
+  const departmentUsage: DepartmentUsage[] = payload.department_usage.map((item) => {
+    const date = new Date(item.period);
+    const periodLabel = date.toLocaleDateString('th-TH', {
+      year: 'numeric',
+      month: 'short',
+    });
+    return { ...item, periodLabel };
+  });
+
+  const driverPerformance: DriverPerformance[] = payload.driver_performance.map((item) => ({
+    ...item,
+  }));
+
+  const expenseSummary: ExpenseAnalytics = {
+    generatedAt: payload.expense_summary.generated_at,
+    totalJobs: payload.expense_summary.total_jobs,
+    totalFuelCost: parseNumber(payload.expense_summary.total_fuel_cost),
+    totalTollCost: parseNumber(payload.expense_summary.total_toll_cost),
+    totalOtherExpenses: parseNumber(payload.expense_summary.total_other_expenses),
+    totalExpenses: parseNumber(payload.expense_summary.total_expenses),
+    averageFuelCost: parseNumber(payload.expense_summary.average_fuel_cost),
+    averageTotalExpense: parseNumber(payload.expense_summary.average_total_expense),
+    statusBreakdown: payload.expense_summary.status_breakdown.map((entry) => ({
+      status: entry.status,
+      count: entry.count,
+      totalExpenses: parseNumber(entry.total_expenses),
+    })),
+  };
+
+  const predictiveMaintenance: PredictiveMaintenance[] = payload.predictive_maintenance.map((item) => ({
+    ...item,
+    projectedServiceLabel: new Date(item.projected_service_date).toLocaleDateString('th-TH', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }),
+  }));
+
+  const bookingPatterns: BookingPattern[] = payload.booking_patterns.map((item) => ({
+    ...item,
+  }));
+
+  const costRecommendations: CostRecommendation[] = payload.cost_recommendations.map((item) => ({
+    ...item,
+  }));
+
+  const customReportSummary: CustomReportSummary = {
+    totalBookings: payload.custom_report_summary.total_bookings,
+    totalCompleted: payload.custom_report_summary.total_completed,
+    totalExpenses: payload.custom_report_summary.total_expenses,
+    averageBookingHours: payload.custom_report_summary.average_booking_hours,
+    filters: payload.custom_report_summary.filters,
+  };
+
+  const customReportOptions: CustomReportOptions = {
+    departments: payload.custom_report_options.departments,
+    vehicleTypes: payload.custom_report_options.vehicle_types,
+    drivers: payload.custom_report_options.drivers,
+  };
+
+  return {
+    generatedAt: payload.generated_at,
+    timeframeStart: payload.timeframe_start,
+    timeframeEnd: payload.timeframe_end,
+    vehicleUtilisation,
+    departmentUsage,
+    driverPerformance,
+    expenseSummary,
+    predictiveMaintenance,
+    bookingPatterns,
+    costRecommendations,
+    customReportSummary,
+    customReportOptions,
+  };
+}
+
+export default function ReportsPage() {
+  const { authenticatedFetch } = useAuth();
+  const [data, setData] = useState<ReportOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [appliedFilters, setAppliedFilters] = useState<ReportFilters>(initialFilters);
+  const [formState, setFormState] = useState<ReportFilters>(initialFilters);
+
+  const fetchReports = useCallback(
+    async (filters: ReportFilters) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (filters.start) {
+          params.set('start', toIsoBoundary(filters.start));
+        }
+        if (filters.end) {
+          params.set('end', toIsoBoundary(filters.end, true));
+        }
+        if (filters.department) {
+          params.set('department', filters.department);
+        }
+        if (filters.vehicleType) {
+          params.set('vehicle_type', filters.vehicleType);
+        }
+        filters.drivers.forEach((driverId) => {
+          params.append('drivers', String(driverId));
+        });
+
+        const query = params.toString();
+        const endpoint = `${API_URL}/api/v1/reports/overview${query ? `?${query}` : ''}`;
+        const response = await authenticatedFetch(endpoint);
+        if (!response.ok) {
+          const details = await response.json().catch(() => ({}));
+          const message = typeof details?.detail === 'string' ? details.detail : 'ไม่สามารถโหลดรายงานได้';
+          throw new Error(message);
+        }
+        const payload = (await response.json()) as RawReportOverview;
+        setData(normaliseReport(payload));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'เกิดข้อผิดพลาดไม่ทราบสาเหตุ';
+        setError(message);
+        setData(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [authenticatedFetch],
+  );
+
+  useEffect(() => {
+    fetchReports(appliedFilters).catch(() => {
+      // error state handled in fetchReports
+    });
+  }, [appliedFilters, fetchReports]);
+
+  const averageUtilisation = useMemo(() => {
+    if (!data || data.vehicleUtilisation.length === 0) return 0;
+    const total = data.vehicleUtilisation.reduce((sum, item) => sum + item.utilisation_rate, 0);
+    return total / data.vehicleUtilisation.length;
+  }, [data]);
+
+  const totalRequests = useMemo(() => {
+    if (!data) return 0;
+    return data.departmentUsage.reduce((sum, item) => sum + item.total_requests, 0);
+  }, [data]);
+
+  const activeDrivers = useMemo(() => data?.driverPerformance.length ?? 0, [data]);
+
+  const monthlyAggregation = useMemo(() => {
+    if (!data) return [] as { label: string; value: number; detail: string }[];
+    const map = new Map<string, { value: number; passengers: number }>();
+    data.departmentUsage.forEach((item) => {
+      const existing = map.get(item.periodLabel) ?? { value: 0, passengers: 0 };
+      existing.value += item.total_requests;
+      existing.passengers += item.total_passengers;
+      map.set(item.periodLabel, existing);
+    });
+    return Array.from(map.entries()).map(([label, { value, passengers }]) => ({
+      label,
+      value,
+      detail: `${passengers.toLocaleString()} คน`,
+    }));
+  }, [data]);
+
+  const expenseStacked = useMemo(() => {
+    if (!data) return [];
+    const total = data.expenseSummary.totalExpenses;
+    const accentMap: Record<string, 'primary' | 'emerald' | 'amber' | 'rose' | 'violet' | 'slate'> = {
+      APPROVED: 'emerald',
+      PENDING_REVIEW: 'amber',
+      NOT_SUBMITTED: 'slate',
+      REJECTED: 'rose',
+      COMPLETED: 'primary',
+    };
+    return [
+      {
+        label: 'ภาพรวมค่าใช้จ่าย',
+        total,
+        segments: data.expenseSummary.statusBreakdown.map((entry) => ({
+          value: entry.totalExpenses,
+          accent: accentMap[entry.status] ?? 'primary',
+        })),
+      },
+    ];
+  }, [data]);
+
+  const appliedFilterSummary = useMemo(() => {
+    const parts: string[] = [];
+    if (appliedFilters.start) {
+      parts.push(`ตั้งแต่ ${new Date(appliedFilters.start).toLocaleDateString('th-TH')}`);
+    }
+    if (appliedFilters.end) {
+      parts.push(`ถึง ${new Date(appliedFilters.end).toLocaleDateString('th-TH')}`);
+    }
+    if (appliedFilters.department) {
+      parts.push(`หน่วยงาน ${appliedFilters.department}`);
+    }
+    if (appliedFilters.vehicleType) {
+      parts.push(`ประเภทรถ ${appliedFilters.vehicleType}`);
+    }
+    if (appliedFilters.drivers.length > 0 && data) {
+      const labels = data.customReportOptions.drivers
+        .filter((driver) => appliedFilters.drivers.includes(driver.id))
+        .map((driver) => driver.name);
+      if (labels.length > 0) {
+        parts.push(`คนขับ ${labels.join(', ')}`);
+      }
+    }
+    return parts.length > 0 ? parts.join(' • ') : 'ทั้งหมด';
+  }, [appliedFilters, data]);
+
+  const handleFilterChange = (field: keyof ReportFilters, value: string | number) => {
+    setFormState((prev) => {
+      if (field === 'drivers' && typeof value === 'number') {
+        const exists = prev.drivers.includes(value);
+        const drivers = exists ? prev.drivers.filter((id) => id !== value) : [...prev.drivers, value];
+        return { ...prev, drivers };
+      }
+      if (field === 'start' || field === 'end' || field === 'department' || field === 'vehicleType') {
+        return { ...prev, [field]: String(value) };
+      }
+      return prev;
+    });
+  };
+
+  const handleApplyFilters = () => {
+    setAppliedFilters(formState);
+  };
+
+  const handleResetFilters = () => {
+    setFormState(initialFilters);
+    setAppliedFilters(initialFilters);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-primary-50/80 via-white to-secondary-50/70 py-10">
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-8 flex flex-col gap-3">
+          <div className="inline-flex items-center gap-2 self-start rounded-full border border-primary-200 bg-white/70 px-4 py-1 text-xs font-semibold text-primary-600 shadow-sm">
+            <BarChart3 className="h-3.5 w-3.5" /> ระบบรายงานและการวิเคราะห์
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900">แดชบอร์ดรายงานภาพรวม</h1>
+          <p className="text-sm text-gray-600">
+            ติดตามประสิทธิภาพการใช้รถ ค่าใช้จ่าย แนวโน้มการจอง และคำแนะนำเพื่อเพิ่มประสิทธิภาพการบริหารจัดการยานพาหนะ
+          </p>
+        </div>
+
+        <CardGrid>
+          <StatCard
+            label="อัตราการใช้งานเฉลี่ย"
+            value={`${averageUtilisation.toFixed(1)}%`}
+            icon={Gauge}
+            accent="primary"
+            trend={{ value: appliedFilterSummary, direction: 'steady' }}
+          />
+          <StatCard
+            label="คำขอทั้งหมดในช่วง"
+            value={totalRequests.toLocaleString('th-TH')}
+            icon={Activity}
+            accent="emerald"
+            trend={{ value: `${appliedFilters.start || 'เริ่มต้น'} - ${appliedFilters.end || 'ปัจจุบัน'}`, direction: 'up' }}
+          />
+          <StatCard
+            label="ค่าใช้จ่ายรวม"
+            value={formatCurrency(data?.expenseSummary.totalExpenses ?? 0)}
+            icon={Fuel}
+            accent="amber"
+            trend={{ value: `${data?.expenseSummary.totalJobs ?? 0} งาน`, direction: 'steady' }}
+          />
+          <StatCard
+            label="จำนวนคนขับที่มีข้อมูล"
+            value={`${activeDrivers} คน`}
+            icon={Users2}
+            accent="violet"
+            trend={{ value: 'ปรับตามข้อมูลจริง', direction: 'steady' }}
+          />
+        </CardGrid>
+
+        <div className="mt-8 grid gap-6 lg:grid-cols-[360px_1fr]">
+          <SectionCard
+            title="ตัวกรองรายงาน"
+            description="ปรับแต่งช่วงเวลาและหน่วยงานเพื่อสร้างรายงานแบบกำหนดเอง"
+            icon={Filter}
+            actions={
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleResetFilters}
+                  className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50"
+                >
+                  รีเซ็ต
+                </button>
+                <button
+                  type="button"
+                  onClick={handleApplyFilters}
+                  className="rounded-lg bg-primary-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-primary-700"
+                >
+                  นำไปใช้
+                </button>
+              </div>
+            }
+          >
+            <div className="space-y-4 text-sm text-gray-600">
+              <div className="grid gap-3">
+                <label className="text-xs font-semibold text-gray-500">วันที่เริ่มต้น</label>
+                <input
+                  type="date"
+                  value={formState.start}
+                  onChange={(event) => handleFilterChange('start', event.target.value)}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                />
+              </div>
+              <div className="grid gap-3">
+                <label className="text-xs font-semibold text-gray-500">วันที่สิ้นสุด</label>
+                <input
+                  type="date"
+                  value={formState.end}
+                  onChange={(event) => handleFilterChange('end', event.target.value)}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                />
+              </div>
+              <div className="grid gap-3">
+                <label className="text-xs font-semibold text-gray-500">หน่วยงาน</label>
+                <select
+                  value={formState.department}
+                  onChange={(event) => handleFilterChange('department', event.target.value)}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                >
+                  <option value="">ทั้งหมด</option>
+                  {data?.customReportOptions.departments.map((department) => (
+                    <option key={department} value={department}>
+                      {department}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid gap-3">
+                <label className="text-xs font-semibold text-gray-500">ประเภทยานพาหนะ</label>
+                <select
+                  value={formState.vehicleType}
+                  onChange={(event) => handleFilterChange('vehicleType', event.target.value)}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                >
+                  <option value="">ทั้งหมด</option>
+                  {data?.customReportOptions.vehicleTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <p className="text-xs font-semibold text-gray-500">เลือกรายชื่อคนขับ</p>
+                <div className="grid gap-2">
+                  {data?.customReportOptions.drivers.map((driver) => {
+                    const checked = formState.drivers.includes(driver.id);
+                    return (
+                      <label key={driver.id} className="flex items-center gap-2 text-xs">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => handleFilterChange('drivers', driver.id)}
+                          className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                        />
+                        <span>{driver.name}</span>
+                      </label>
+                    );
+                  })}
+                  {data && data.customReportOptions.drivers.length === 0 && (
+                    <p className="text-xs text-gray-400">ยังไม่มีข้อมูลคนขับในระบบ</p>
+                  )}
+                </div>
+              </div>
+              <div className="rounded-xl border border-dashed border-gray-200 bg-white/70 p-3 text-xs text-gray-500">
+                <p className="font-semibold text-gray-700">ตัวกรองที่ใช้งาน:</p>
+                <p className="mt-1 text-gray-600">{appliedFilterSummary}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => fetchReports(appliedFilters)}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-primary-200 bg-white/70 px-3 py-1.5 text-xs font-semibold text-primary-600 hover:bg-primary-50"
+              >
+                <RefreshCcw className="h-3.5 w-3.5" /> โหลดข้อมูลล่าสุด
+              </button>
+              {error && <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-600">{error}</p>}
+              {loading && <p className="text-xs text-gray-500">กำลังโหลดข้อมูล...</p>}
+            </div>
+          </SectionCard>
+
+          <div className="space-y-6">
+            <SectionCard
+              title="อัตราการใช้งานยานพาหนะ"
+              description="ติดตามการใช้รถแต่ละคัน พร้อมระบุชั่วโมงปฏิบัติงานและความหนาแน่น"
+              icon={Gauge}
+            >
+              {data ? (
+                <div className="grid gap-6 lg:grid-cols-2">
+                  <HorizontalBarChart
+                    data={data.vehicleUtilisation.map((item) => ({
+                      label: `${item.registration_number} (${item.vehicle_type})`,
+                      value: item.utilisation_rate,
+                      hint: `${item.total_trips} งาน • ${item.total_hours.toFixed(1)} ชม. • ${item.current_mileage.toLocaleString()} กม.`,
+                    }))}
+                  />
+                  <div className="space-y-3 rounded-2xl border border-gray-100 bg-white/80 p-5 shadow-sm">
+                    <h3 className="text-sm font-semibold text-gray-800">สรุปเชิงลึก</h3>
+                    <ul className="space-y-2 text-xs text-gray-600">
+                      <li className="flex items-start gap-2"><Sparkles className="mt-0.5 h-3.5 w-3.5 text-primary-500" />
+                        รถ {data.vehicleUtilisation[0]?.registration_number ?? '—'} มีการใช้งานสูงสุด {data.vehicleUtilisation[0]?.utilisation_rate.toFixed(1) ?? '0'}%</li>
+                      <li className="flex items-start gap-2"><LineChart className="mt-0.5 h-3.5 w-3.5 text-emerald-500" />
+                        ค่าเฉลี่ยระยะเวลาต่อทริป {data.vehicleUtilisation.length > 0 ? (data.vehicleUtilisation.reduce((sum, item) => sum + item.average_trip_duration_hours, 0) / data.vehicleUtilisation.length).toFixed(1) : '0'} ชั่วโมง</li>
+                      <li className="flex items-start gap-2"><Factory className="mt-0.5 h-3.5 w-3.5 text-amber-500" />
+                        มี {data.vehicleUtilisation.filter((item) => item.utilisation_rate < 40).length} คันที่ต้องติดตามเพิ่มเพื่อเพิ่มอัตราการใช้งาน</li>
+                    </ul>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ยังไม่มีข้อมูล</p>
+              )}
+            </SectionCard>
+
+            <SectionCard
+              title="รายงานการใช้งานรายเดือนตามหน่วยงาน"
+              description="ดูจำนวนคำขอและผู้โดยสารเพื่อวางแผนทรัพยากร"
+              icon={CalendarClock}
+            >
+              {data && monthlyAggregation.length > 0 ? (
+                <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+                  <SimpleColumnChart data={monthlyAggregation.slice(-5)} />
+                  <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white/70 shadow-sm">
+                    <table className="min-w-full divide-y divide-gray-100 text-left text-xs">
+                      <thead className="bg-primary-50 text-gray-600">
+                        <tr>
+                          <th className="px-4 py-2 font-semibold">เดือน</th>
+                          <th className="px-4 py-2 font-semibold">หน่วยงาน</th>
+                          <th className="px-4 py-2 font-semibold">คำขอ</th>
+                          <th className="px-4 py-2 font-semibold">เสร็จสมบูรณ์</th>
+                          <th className="px-4 py-2 font-semibold">ผู้โดยสาร</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100 bg-white/70">
+                        {data.departmentUsage.map((item) => (
+                          <tr key={`${item.period}-${item.department}`} className="hover:bg-primary-50/40">
+                            <td className="px-4 py-2 text-gray-700">{item.periodLabel}</td>
+                            <td className="px-4 py-2 text-gray-700">{item.department}</td>
+                            <td className="px-4 py-2 text-gray-600">{item.total_requests.toLocaleString('th-TH')}</td>
+                            <td className="px-4 py-2 text-gray-600">{item.completed_trips.toLocaleString('th-TH')}</td>
+                            <td className="px-4 py-2 text-gray-600">{item.total_passengers.toLocaleString('th-TH')}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ยังไม่มีข้อมูลคำขอในช่วงที่เลือก</p>
+              )}
+            </SectionCard>
+
+            <SectionCard
+              title="ประสิทธิภาพและภาระงานของคนขับ"
+              description="ระบุคนขับที่มีภาระงานสูงและค่าเฉลี่ยเวลาปฏิบัติงาน"
+              icon={Users2}
+            >
+              {data && data.driverPerformance.length > 0 ? (
+                <div className="space-y-4">
+                  {data.driverPerformance.map((driver) => {
+                    const completionRate = driver.assignments === 0 ? 0 : (driver.completed_jobs / driver.assignments) * 100;
+                    return (
+                      <div key={driver.driver_id} className="rounded-2xl border border-gray-100 bg-white/70 p-4 shadow-sm">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-gray-900">{driver.full_name}</p>
+                            <p className="text-xs text-gray-500">{driver.assignments.toLocaleString('th-TH')} งาน • {driver.total_hours.toFixed(1)} ชั่วโมง</p>
+                          </div>
+                          <TrendPill label="อัตราสำเร็จ" value={`${completionRate.toFixed(1)}%`} />
+                        </div>
+                        <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-gray-100">
+                          <div className="h-full rounded-full bg-emerald-500" style={{ width: `${Math.min(100, completionRate)}%` }} />
+                        </div>
+                        <p className="mt-2 text-xs text-gray-500">เฉลี่ย {driver.average_completion_time_hours.toFixed(1)} ชม./งาน • ดัชนีภาระงาน {driver.workload_index.toFixed(1)}%</p>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ยังไม่มีข้อมูลการปฏิบัติงานของคนขับ</p>
+              )}
+            </SectionCard>
+
+            <SectionCard
+              title="การติดตามค่าใช้จ่าย"
+              description="สรุปค่าใช้จ่ายตามสถานะการอนุมัติและค่าเฉลี่ยต่อทริป"
+              icon={Fuel}
+            >
+              {data ? (
+                <div className="grid gap-5 lg:grid-cols-[300px_1fr]">
+                  <div className="rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm">
+                    <h3 className="text-sm font-semibold text-gray-800">สถานะค่าใช้จ่าย</h3>
+                    <StackedProgressBar data={expenseStacked} />
+                    <div className="mt-4 space-y-2 text-xs text-gray-600">
+                      {data.expenseSummary.statusBreakdown.map((entry) => (
+                        <div key={entry.status} className="flex items-center justify-between rounded-lg border border-gray-100 bg-white/70 px-3 py-2">
+                          <span className="font-medium text-gray-700">{entry.status}</span>
+                          <span>{formatCurrency(entry.totalExpenses)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm">
+                      <p className="text-xs font-semibold text-gray-500">ค่าใช้จ่ายเฉลี่ยต่อทริป</p>
+                      <p className="mt-2 text-xl font-bold text-gray-900">{formatCurrency(data.expenseSummary.averageTotalExpense)}</p>
+                      <p className="mt-1 text-xs text-gray-500">จากทั้งหมด {data.expenseSummary.totalJobs.toLocaleString('th-TH')} งาน</p>
+                    </div>
+                    <div className="rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm">
+                      <p className="text-xs font-semibold text-gray-500">ค่าเชื้อเพลิงรวม</p>
+                      <p className="mt-2 text-xl font-bold text-gray-900">{formatCurrency(data.expenseSummary.totalFuelCost)}</p>
+                      <p className="mt-1 text-xs text-gray-500">รวมค่าทางด่วน {formatCurrency(data.expenseSummary.totalTollCost)} และอื่น ๆ {formatCurrency(data.expenseSummary.totalOtherExpenses)}</p>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ไม่มีข้อมูลค่าใช้จ่าย</p>
+              )}
+            </SectionCard>
+
+            <SectionCard
+              title="การบำรุงรักษาเชิงคาดการณ์"
+              description="วิเคราะห์ความเสี่ยงและแนะนำการวางแผนงานบำรุงรักษา"
+              icon={Sparkles}
+            >
+              {data && data.predictiveMaintenance.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2">
+                  {data.predictiveMaintenance.map((item) => (
+                    <div key={item.vehicle_id} className="rounded-2xl border border-gray-100 bg-gradient-to-br from-white/90 to-primary-50/60 p-4 shadow-sm">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-gray-900">{item.registration_number}</p>
+                          <p className="text-xs text-gray-500">ประเภท {item.vehicle_type}</p>
+                        </div>
+                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-100 text-sm font-bold text-primary-700">
+                          {item.risk_score.toFixed(0)}%
+                        </div>
+                      </div>
+                      <p className="mt-3 text-xs text-gray-600">{item.recommended_action}</p>
+                      <p className="mt-2 text-xs font-semibold text-primary-600">ควรดำเนินการก่อน: {item.projectedServiceLabel}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ยังไม่มีความเสี่ยงที่ต้องติดตามเป็นพิเศษ</p>
+              )}
+            </SectionCard>
+
+            <SectionCard
+              title="การวิเคราะห์รูปแบบการจอง"
+              description="ดูแนวโน้มวันที่มีการใช้งานสูงและช่วงเวลาที่ได้รับความนิยม"
+              icon={Activity}
+            >
+              {data && data.bookingPatterns.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-3 rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm">
+                    <h3 className="text-sm font-semibold text-gray-800">รูปแบบตามวัน</h3>
+                    <ul className="space-y-2 text-xs text-gray-600">
+                      {data.bookingPatterns.map((pattern) => (
+                        <li key={pattern.weekday_index} className="flex items-center justify-between rounded-lg border border-gray-100 bg-white/70 px-3 py-2">
+                          <span className="font-medium text-gray-700">{pattern.day_of_week}</span>
+                          <span>{pattern.average_bookings.toFixed(1)} งาน/วัน</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm">
+                    <h3 className="text-sm font-semibold text-gray-800">คำแนะนำในการจัดการ</h3>
+                    <ul className="space-y-2 text-xs text-gray-600">
+                      <li className="flex items-start gap-2"><TrendingUp className="mt-0.5 h-3.5 w-3.5 text-primary-500" />
+                        จัดเพิ่มรถสำรองในช่วง {Math.round(data.bookingPatterns[0].peak_hour).toString().padStart(2, '0')}:00 น. ของวันยอดนิยม</li>
+                      <li className="flex items-start gap-2"><LineChart className="mt-0.5 h-3.5 w-3.5 text-emerald-500" />
+                        พิจารณาควบรวมคำขอที่มีจำนวนผู้โดยสารน้อยกว่า 3 คนในวันอัตราใช้งานต่ำ</li>
+                      <li className="flex items-start gap-2"><Activity className="mt-0.5 h-3.5 w-3.5 text-amber-500" />
+                        ใช้ข้อมูลนี้เพื่อแจ้งเตือนผู้อนุมัติให้เตรียมพร้อมในช่วงเวลาที่มีคำขอหนาแน่น</li>
+                    </ul>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ยังไม่มีข้อมูลรูปแบบการจอง</p>
+              )}
+            </SectionCard>
+
+            <SectionCard
+              title="คำแนะนำการปรับค่าใช้จ่าย"
+              description="ข้อเสนอเพื่อเพิ่มประสิทธิภาพการใช้งบประมาณ"
+              icon={TrendingUp}
+            >
+              {data && data.costRecommendations.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2">
+                  {data.costRecommendations.map((item) => (
+                    <div key={item.label} className="rounded-2xl border border-gray-100 bg-gradient-to-br from-emerald-50/80 to-white/80 p-4 shadow-sm">
+                      <p className="text-sm font-semibold text-gray-900">{item.label}</p>
+                      <p className="mt-2 text-xs text-gray-600">{item.detail}</p>
+                      <p className="mt-3 inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                        ศักยภาพในการประหยัด {formatCurrency(item.potential_saving)} ต่อทริป
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ยังไม่มีคำแนะนำเพิ่มเติม</p>
+              )}
+            </SectionCard>
+
+            <SectionCard
+              title="สรุปรายงานแบบกำหนดเอง"
+              description="สรุปผลลัพธ์จากตัวกรองที่เลือกไว้"
+              icon={BarChart3}
+            >
+              {data ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm">
+                    <p className="text-xs font-semibold text-gray-500">คำขอที่อยู่ในช่วง</p>
+                    <p className="mt-2 text-xl font-bold text-gray-900">{data.customReportSummary.totalBookings.toLocaleString('th-TH')}</p>
+                    <p className="mt-1 text-xs text-gray-500">เสร็จสมบูรณ์ {data.customReportSummary.totalCompleted.toLocaleString('th-TH')} งาน</p>
+                  </div>
+                  <div className="rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm">
+                    <p className="text-xs font-semibold text-gray-500">ค่าใช้จ่ายรวม</p>
+                    <p className="mt-2 text-xl font-bold text-gray-900">{formatCurrency(data.customReportSummary.totalExpenses)}</p>
+                    <p className="mt-1 text-xs text-gray-500">เฉลี่ย {data.customReportSummary.averageBookingHours.toFixed(1)} ชม./งาน</p>
+                  </div>
+                  <div className="rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm sm:col-span-2">
+                    <p className="text-xs font-semibold text-gray-500">รายละเอียดตัวกรองที่ใช้</p>
+                    <pre className="mt-2 whitespace-pre-wrap text-xs text-gray-600">
+                      {JSON.stringify(data.customReportSummary.filters, null, 2) || 'ไม่พบตัวกรอง'}
+                    </pre>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">ยังไม่มีข้อมูลสรุป</p>
+              )}
+            </SectionCard>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reports/types.ts
+++ b/frontend/src/components/reports/types.ts
@@ -1,0 +1,158 @@
+export interface RawVehicleUtilisation {
+  vehicle_id: number;
+  registration_number: string;
+  vehicle_type: string;
+  total_trips: number;
+  total_hours: number;
+  active_days: number;
+  average_trip_duration_hours: number;
+  utilisation_rate: number;
+  current_mileage: number;
+}
+
+export interface RawDepartmentUsage {
+  period: string;
+  department: string;
+  total_requests: number;
+  completed_trips: number;
+  total_passengers: number;
+  total_hours: number;
+}
+
+export interface RawDriverPerformance {
+  driver_id: number;
+  full_name: string;
+  assignments: number;
+  completed_jobs: number;
+  total_hours: number;
+  average_completion_time_hours: number;
+  workload_index: number;
+}
+
+export interface RawPredictiveMaintenance {
+  vehicle_id: number;
+  registration_number: string;
+  vehicle_type: string;
+  risk_score: number;
+  recommended_action: string;
+  projected_service_date: string;
+}
+
+export interface RawBookingPattern {
+  day_of_week: string;
+  weekday_index: number;
+  average_bookings: number;
+  peak_hour: number;
+  average_passengers: number;
+}
+
+export interface RawCostRecommendation {
+  label: string;
+  detail: string;
+  potential_saving: number;
+}
+
+export interface RawExpenseStatusEntry {
+  status: string;
+  count: number;
+  total_expenses: string | number;
+}
+
+export interface RawExpenseAnalytics {
+  generated_at: string;
+  total_jobs: number;
+  total_fuel_cost: string | number;
+  total_toll_cost: string | number;
+  total_other_expenses: string | number;
+  total_expenses: string | number;
+  average_fuel_cost: string | number;
+  average_total_expense: string | number;
+  status_breakdown: RawExpenseStatusEntry[];
+}
+
+export interface RawCustomReportSummary {
+  total_bookings: number;
+  total_completed: number;
+  total_expenses: number;
+  average_booking_hours: number;
+  filters: Record<string, unknown>;
+}
+
+export interface RawCustomReportOptions {
+  departments: string[];
+  vehicle_types: string[];
+  drivers: { id: number; name: string }[];
+}
+
+export interface RawReportOverview {
+  generated_at: string;
+  timeframe_start: string | null;
+  timeframe_end: string | null;
+  vehicle_utilisation: RawVehicleUtilisation[];
+  department_usage: RawDepartmentUsage[];
+  driver_performance: RawDriverPerformance[];
+  expense_summary: RawExpenseAnalytics;
+  predictive_maintenance: RawPredictiveMaintenance[];
+  booking_patterns: RawBookingPattern[];
+  cost_recommendations: RawCostRecommendation[];
+  custom_report_summary: RawCustomReportSummary;
+  custom_report_options: RawCustomReportOptions;
+}
+
+export interface VehicleUtilisation extends RawVehicleUtilisation {}
+export interface DepartmentUsage extends RawDepartmentUsage {
+  periodLabel: string;
+}
+export interface DriverPerformance extends RawDriverPerformance {}
+export interface PredictiveMaintenance extends RawPredictiveMaintenance {
+  projectedServiceLabel: string;
+}
+export interface BookingPattern extends RawBookingPattern {}
+export interface CostRecommendation extends RawCostRecommendation {}
+
+export interface ExpenseStatusEntry {
+  status: string;
+  count: number;
+  totalExpenses: number;
+}
+
+export interface ExpenseAnalytics {
+  generatedAt: string;
+  totalJobs: number;
+  totalFuelCost: number;
+  totalTollCost: number;
+  totalOtherExpenses: number;
+  totalExpenses: number;
+  averageFuelCost: number;
+  averageTotalExpense: number;
+  statusBreakdown: ExpenseStatusEntry[];
+}
+
+export interface CustomReportSummary {
+  totalBookings: number;
+  totalCompleted: number;
+  totalExpenses: number;
+  averageBookingHours: number;
+  filters: Record<string, unknown>;
+}
+
+export interface CustomReportOptions {
+  departments: string[];
+  vehicleTypes: string[];
+  drivers: { id: number; name: string }[];
+}
+
+export interface ReportOverview {
+  generatedAt: string;
+  timeframeStart: string | null;
+  timeframeEnd: string | null;
+  vehicleUtilisation: VehicleUtilisation[];
+  departmentUsage: DepartmentUsage[];
+  driverPerformance: DriverPerformance[];
+  expenseSummary: ExpenseAnalytics;
+  predictiveMaintenance: PredictiveMaintenance[];
+  bookingPatterns: BookingPattern[];
+  costRecommendations: CostRecommendation[];
+  customReportSummary: CustomReportSummary;
+  customReportOptions: CustomReportOptions;
+}

--- a/frontend/src/components/reports/visuals.tsx
+++ b/frontend/src/components/reports/visuals.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import clsx from 'clsx';
+
+interface HorizontalBarDatum {
+  label: string;
+  value: number;
+  hint?: string;
+  accent?: 'primary' | 'emerald' | 'amber' | 'rose' | 'slate';
+}
+
+const accentMap: Record<NonNullable<HorizontalBarDatum['accent']>, string> = {
+  primary: 'bg-primary-500',
+  emerald: 'bg-emerald-500',
+  amber: 'bg-amber-400',
+  rose: 'bg-rose-500',
+  slate: 'bg-slate-500',
+};
+
+export function HorizontalBarChart({
+  data,
+  maxValue = 100,
+  unit = '%',
+}: {
+  data: HorizontalBarDatum[];
+  maxValue?: number;
+  unit?: string;
+}) {
+  return (
+    <div className="space-y-4">
+      {data.map((item) => {
+        const width = Math.max(2, Math.min(100, (item.value / maxValue) * 100));
+        const accent = accentMap[item.accent ?? 'primary'];
+        return (
+          <div key={item.label}>
+            <div className="flex items-center justify-between text-xs font-medium text-gray-600">
+              <span>{item.label}</span>
+              <span className="text-gray-800">{item.value.toFixed(1)}{unit}</span>
+            </div>
+            <div className="mt-1 h-2.5 rounded-full bg-gray-100">
+              <div
+                className={clsx('h-2.5 rounded-full transition-all duration-500', accent)}
+                style={{ width: `${width}%` }}
+              />
+            </div>
+            {item.hint && <p className="mt-1 text-[11px] text-gray-500">{item.hint}</p>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ColumnChartDatum {
+  label: string;
+  value: number;
+  detail?: string;
+}
+
+export function SimpleColumnChart({ data, maxValue }: { data: ColumnChartDatum[]; maxValue?: number }) {
+  const computedMax = maxValue ?? Math.max(...data.map((item) => item.value), 1);
+  return (
+    <div className="flex items-end gap-4">
+      {data.map((item) => {
+        const height = Math.round((item.value / computedMax) * 160);
+        return (
+          <div key={item.label} className="flex flex-col items-center text-xs text-gray-600">
+            <div className="flex h-40 w-10 items-end justify-center rounded-t-lg bg-gradient-to-t from-primary-100 to-primary-400/70">
+              <div className="w-7 rounded-t-lg bg-primary-500 shadow-md" style={{ height: `${height}px` }} />
+            </div>
+            <span className="mt-2 font-medium">{item.label}</span>
+            {item.detail && <span className="text-[11px] text-gray-500">{item.detail}</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface StackedBarDatum {
+  label: string;
+  segments: { value: number; accent: 'primary' | 'emerald' | 'amber' | 'rose' | 'violet' | 'slate'; }[];
+  total: number;
+}
+
+const stackedAccentMap: Record<StackedBarDatum['segments'][number]['accent'], string> = {
+  primary: 'bg-primary-500',
+  emerald: 'bg-emerald-500',
+  amber: 'bg-amber-400',
+  rose: 'bg-rose-500',
+  violet: 'bg-violet-500',
+  slate: 'bg-slate-400',
+};
+
+export function StackedProgressBar({ data }: { data: StackedBarDatum[] }) {
+  return (
+    <div className="space-y-4">
+      {data.map((item) => (
+        <div key={item.label}>
+          <div className="flex items-center justify-between text-xs font-medium text-gray-600">
+            <span>{item.label}</span>
+            <span className="text-gray-800">รวม {item.total.toLocaleString()} บาท</span>
+          </div>
+          <div className="mt-1 flex h-3 overflow-hidden rounded-full bg-gray-100 shadow-inner">
+            {item.segments.map((segment, index) => {
+              const width = item.total === 0 ? 0 : Math.max(2, (segment.value / item.total) * 100);
+              return (
+                <div
+                  key={`${item.label}-${index}`}
+                  className={clsx('h-full transition-all duration-500', stackedAccentMap[segment.accent])}
+                  style={{ width: `${width}%` }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TrendPill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-primary-200 bg-primary-50 px-3 py-1 text-xs font-medium text-primary-600">
+      <span className="inline-flex h-1.5 w-1.5 rounded-full bg-primary-500" />
+      <span>{label}: {value}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add comprehensive reporting service to aggregate utilisation, expenses, and predictive maintenance metrics
- expose protected reporting API endpoints and schemas for delivering analytics payloads
- build interactive reporting dashboard with filters, charts, and advanced optimisation insights

## Testing
- pytest
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca70dcb9208328bd116c74d35932f7