### PR TITLE
Add Tailwind CSS plugin dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,8 @@
     "@typescript-eslint/parser": "^6.15.0",
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "^0.5.9",
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.10",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "@testing-library/react": "^14.1.2",


### PR DESCRIPTION
## Summary
- add the missing Tailwind CSS plugin packages for forms and typography to the frontend devDependencies

## Testing
- npm install *(fails: registry returned 403 for @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb9546ccc8328af15bbd17249e6e4