### PR TITLE
Fix Alembic MySQL column update syntax

### DIFF
--- a/backend/alembic/versions/20240219_0001_initial_schema.py
+++ b/backend/alembic/versions/20240219_0001_initial_schema.py
@@ -135,7 +135,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.text("CURRENT_TIMESTAMP"),
-            mysql_on_update=sa.text("CURRENT_TIMESTAMP"),
+            server_onupdate=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
     op.create_index("ix_users_role", "users", ["role"], unique=False)
@@ -187,7 +187,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.text("CURRENT_TIMESTAMP"),
-            mysql_on_update=sa.text("CURRENT_TIMESTAMP"),
+            server_onupdate=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
     op.create_index(
@@ -245,7 +245,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.text("CURRENT_TIMESTAMP"),
-            mysql_on_update=sa.text("CURRENT_TIMESTAMP"),
+            server_onupdate=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
     op.create_index("ix_drivers_user_id", "drivers", ["user_id"], unique=False)
@@ -303,7 +303,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.text("CURRENT_TIMESTAMP"),
-            mysql_on_update=sa.text("CURRENT_TIMESTAMP"),
+            server_onupdate=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
     op.create_index(
@@ -461,7 +461,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.text("CURRENT_TIMESTAMP"),
-            mysql_on_update=sa.text("CURRENT_TIMESTAMP"),
+            server_onupdate=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
     op.create_index("ix_job_runs_status", "job_runs", ["status"], unique=False)

--- a/backend/alembic/versions/backend/alembic/versions/20240501_0003_email_notifications.py
+++ b/backend/alembic/versions/backend/alembic/versions/20240501_0003_email_notifications.py
@@ -58,7 +58,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.text("CURRENT_TIMESTAMP"),
-            mysql_on_update=sa.text("CURRENT_TIMESTAMP"),
+            server_onupdate=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
 


### PR DESCRIPTION
## Summary
- replace deprecated mysql_on_update column argument with server_onupdate across migrations
- ensure Alembic migrations run on SQLAlchemy's MySQL dialect without argument errors

## Testing
- not run (database connection required for alembic upgrade)


------
https://chatgpt.com/codex/tasks/task_e_68cca02217fc8328922d02b695649933