### PR TITLE
Enable FastAPI docs via configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@
 # Application Settings
 ENVIRONMENT=development
 DEBUG=true
+ENABLE_API_DOCS=true
 SECRET_KEY=your-secret-key-change-in-production
 ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=7

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     # Application
     ENVIRONMENT: str = Field(default="development")
     DEBUG: bool = Field(default=True)
+    ENABLE_API_DOCS: bool = Field(default=True)
     SECRET_KEY: str = Field(default="change-me-in-production")
     API_V1_STR: str = Field(default="/api/v1")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,13 +19,19 @@ from app.utils import InvalidTokenError, decode_token
 setup_logging()
 
 # Create FastAPI application
+openapi_url = (
+    f"{settings.API_V1_STR}/openapi.json" if settings.ENABLE_API_DOCS else None
+)
+docs_url = "/docs" if settings.ENABLE_API_DOCS else None
+redoc_url = "/redoc" if settings.ENABLE_API_DOCS else None
+
 app = FastAPI(
     title="Office Vehicle Booking System API",
     description="ระบบจองรถสำนักงาน - Vehicle booking and management system API",
     version="1.0.0",
-    openapi_url=f"{settings.API_V1_STR}/openapi.json" if settings.DEBUG else None,
-    docs_url="/docs" if settings.DEBUG else None,
-    redoc_url="/redoc" if settings.DEBUG else None,
+    openapi_url=openapi_url,
+    docs_url=docs_url,
+    redoc_url=redoc_url,
 )
 
 # Set up CORS
@@ -48,18 +54,29 @@ if not settings.DEBUG:
 app.include_router(api_router, prefix=settings.API_V1_STR)
 
 # Maintenance mode and audit logging middleware
-maintenance_exempt_paths = (
-    f"{settings.API_V1_STR}/system",
-    f"{settings.API_V1_STR}/health",
-    "/health",
-    "/docs",
-    "/openapi",
+maintenance_exempt_paths = tuple(
+    filter(
+        None,
+        (
+            f"{settings.API_V1_STR}/system",
+            f"{settings.API_V1_STR}/health",
+            "/health",
+            docs_url,
+            openapi_url,
+        ),
+    )
 )
 
-audit_ignored_paths = (
-    "/docs",
-    "/openapi",
-    "/static",
+audit_ignored_paths = tuple(
+    filter(
+        None,
+        (
+            docs_url,
+            redoc_url,
+            openapi_url,
+            "/static",
+        ),
+    )
 )
 
 app.add_middleware(


### PR DESCRIPTION
## Summary
- add an `ENABLE_API_DOCS` setting so the FastAPI application can serve documentation outside of debug mode
- adjust the FastAPI app configuration and middleware path exceptions to respect the documentation toggle
- document the new flag in the backend environment example

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cca16c62048328903a75ab99c8e721