### PR TITLE
Handle empty ALLOWED_EXTENSIONS env values gracefully

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,7 +5,7 @@ Application configuration settings
 from typing import List, Optional
 
 from pydantic import Field, field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -91,9 +91,9 @@ class Settings(BaseSettings):
             return [item.strip() for item in value.split(",") if item.strip()]
         return value
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
+    model_config = SettingsConfigDict(
+        env_file=".env", case_sensitive=True, env_ignore_empty=True
+    )
 
 
 # Create settings instance


### PR DESCRIPTION
## Summary
- ensure Pydantic settings ignore empty environment values so ALLOWED_EXTENSIONS falls back to defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca5273834832895a919c1d9b3b2c3