### PR TITLE
Handle comma-separated ALLOWED_ORIGINS

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -110,6 +110,19 @@ class Settings(BaseSettings):
             return [item.strip() for item in value.split(",") if item.strip()]
         return value
 
+    @field_validator("ALLOWED_ORIGINS", mode="before")
+    @classmethod
+    def _parse_allowed_origins(cls, value: Optional[List[str] | str]) -> Optional[List[str]]:
+        """Allow comma separated CORS origins in environment configuration."""
+        if value is None or isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return []
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return value
+
     model_config = SettingsConfigDict(
         env_file=".env",
         case_sensitive=True,


### PR DESCRIPTION
## Summary
- allow the ALLOWED_ORIGINS setting to accept comma-separated strings when loaded from the environment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccaa6bf3308328b0442343be1f3209