### PR TITLE
Fix Tailwind button styles causing build errors

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
   images: {
     domains: ['localhost'],
     unoptimized: process.env.NODE_ENV === 'development',

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -21,7 +21,7 @@
 
 @layer components {
   .btn {
-    @apply inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background;
+    @apply inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-white;
   }
   
   .btn-primary {


### PR DESCRIPTION
## Summary
- replace the shadcn-specific ring utility usage in the shared button styles with standard Tailwind classes
- remove the deprecated experimental.appDir option from the Next.js configuration

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ccad4fa8bc83288a5ca9c7109d99a5