### PR TITLE
Fix metadata viewport configuration

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import Providers from './providers';
@@ -9,12 +9,13 @@ export const metadata: Metadata = {
   title: 'Office Vehicle Booking System',
   description: 'ระบบจองรถสำนักงาน - Vehicle booking and management system',
   manifest: '/manifest.json',
+};
+
+export const viewport: Viewport = {
   themeColor: '#3b82f6',
-  viewport: {
-    width: 'device-width',
-    initialScale: 1,
-    maximumScale: 1,
-  },
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- move theme color and viewport settings to the dedicated viewport export
- keep manifest configuration in metadata export

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb2f73a588328990b427d8ee9c2be