### PR TITLE
Refine font loading to avoid unused preload warning

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,12 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Sarabun:wght@300;400;500;600;700&display=swap');
-
 @layer base {
   html {
-    font-family: 'Inter', 'Sarabun', system-ui, sans-serif;
+    font-family: var(--font-inter), var(--font-sarabun), system-ui, sans-serif;
   }
   
   body {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,9 +1,19 @@
 import type { Metadata, Viewport } from 'next';
-import { Inter } from 'next/font/google';
+import { Inter, Sarabun } from 'next/font/google';
 import './globals.css';
 import Providers from './providers';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-inter',
+});
+
+const sarabun = Sarabun({
+  subsets: ['latin', 'thai'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-sarabun',
+});
 
 export const metadata: Metadata = {
   title: 'Office Vehicle Booking System',
@@ -24,8 +34,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="th">
-      <body className={inter.className}>
+    <html lang="th" className={`${inter.variable} ${sarabun.variable}`}>
+      <body>
         <Providers>
           <div id="root">{children}</div>
         </Providers>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -70,8 +70,13 @@ module.exports = {
         },
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
-        thai: ['Sarabun', 'Inter', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+        thai: [
+          'var(--font-sarabun)',
+          'var(--font-inter)',
+          'system-ui',
+          'sans-serif',
+        ],
       },
       spacing: {
         '18': '4.5rem',


### PR DESCRIPTION
## Summary
- load Inter and Sarabun through next/font to align preloads with actual usage
- remove Google Fonts @imports and switch global styles and Tailwind config to the generated CSS variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb50999b88328b2fdea65c5101306