### PR TITLE
Handle string user roles when issuing auth tokens

### DIFF
--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -85,16 +85,18 @@ async def login(
     access_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     refresh_expires = timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
 
+    role_value = user.role.value if isinstance(user.role, UserRole) else str(user.role)
+
     access_token = create_access_token(
         subject=str(user.id),
         username=user.username,
-        role=user.role.value,
+        role=role_value,
         expires_delta=access_expires,
     )
     refresh_token = create_refresh_token(
         subject=str(user.id),
         username=user.username,
-        role=user.role.value,
+        role=role_value,
         expires_delta=refresh_expires,
     )
 
@@ -153,10 +155,11 @@ async def refresh_access_token(
         )
 
     access_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    role_value = user.role.value if isinstance(user.role, UserRole) else str(user.role)
     new_access_token = create_access_token(
         subject=str(user.id),
         username=user.username,
-        role=user.role.value,
+        role=role_value,
         expires_delta=access_expires,
     )
 


### PR DESCRIPTION
## Summary
- ensure login and refresh endpoints gracefully handle user roles stored as strings
- reuse the resolved role value when building JWT claims so token generation no longer crashes

## Testing
- `poetry run pytest` *(fails: The Poetry configuration is invalid: Either [project.name] or [tool.poetry.name] is required in package mode. Either [project.version] or [tool.poetry.version] is required in package mode.)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2f8efce48328a434e71f647f2b07