### PR TITLE
Handle invalid password hashes gracefully

### DIFF
--- a/backend/app/utils/security.py
+++ b/backend/app/utils/security.py
@@ -25,7 +25,13 @@ def get_password_hash(password: str) -> str:
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Validate that *plain_password* matches *hashed_password*."""
-    return _pwd_context.verify(plain_password, hashed_password)
+    try:
+        return _pwd_context.verify(plain_password, hashed_password)
+    except (TypeError, ValueError):
+        # Passlib raises ``ValueError`` subclasses when the stored hash is malformed
+        # (for example, when legacy records contain plaintext passwords). Treat
+        # these cases as failed verifications instead of bubbling up a 500 error.
+        return False
 
 
 def _create_token(

--- a/backend/tests/test_security_utils.py
+++ b/backend/tests/test_security_utils.py
@@ -1,0 +1,21 @@
+"""Tests for security helper functions."""
+
+from app.utils.security import get_password_hash, verify_password
+
+
+def test_verify_password_with_valid_hash() -> None:
+    """A valid bcrypt hash should validate successfully."""
+    hashed = get_password_hash("s3cret-pass")
+    assert verify_password("s3cret-pass", hashed)
+
+
+def test_verify_password_with_invalid_hash_returns_false() -> None:
+    """Malformed stored hashes should not raise errors during verification."""
+    # When legacy data contains plaintext values, passlib raises ``ValueError``.
+    # The helper should gracefully treat this as a failed verification.
+    assert not verify_password("irrelevant", "plaintext-password")
+
+
+def test_verify_password_with_none_hash_returns_false() -> None:
+    """Missing hashes should be treated as a failed verification."""
+    assert not verify_password("irrelevant", None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- guard password verification against malformed stored hashes so authentication failures return 401 instead of 500
- add regression tests covering valid, malformed, and missing password hashes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6a2b33888328b2b7945e39fdd2e0